### PR TITLE
Test on new Ruby versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,8 @@
 sudo: false
 language: ruby
 rvm:
-  - 2.3.5
-  - 2.4.2
+  - 2.3.6
+  - 2.4.3
+  - 2.5.0
   - ruby-head
 before_install: gem install bundler


### PR DESCRIPTION
Note current `master`branch build can fail with `ruby-head`.
We might allow failling with `ruby-head` on Travis.