### PR TITLE
Fix a failing test

### DIFF
--- a/test/fiddle/test_import.rb
+++ b/test/fiddle/test_import.rb
@@ -149,16 +149,13 @@ module Fiddle
     end
 
     def test_no_message_with_debug
-      # disable bundler
-      orig_RUBYOPT = ENV['RUBYOPT']
-      ENV['RUBYOPT'] = orig_RUBYOPT.gsub(%r|-rbundler/setup|, '') if orig_RUBYOPT
+      # disable all Ruby environment variables
+      orig_RUBYOPT, ENV['RUBYOPT'] = ENV['RUBYOPT'], nil
+      orig_RUBYLIB, ENV['RUBYLIB'] = ENV['RUBYLIB'], nil
 
       # load development fiddle instead of bundled one
-      orig_RUBYLIB = ENV['RUBYLIB']
       libdir = File.expand_path('../../../lib', __FILE__)
-      if File.file?(File.join(libdir, "fiddle/import.rb"))
-        ENV['RUBYLIB'] = [libdir, orig_RUBYLIB].compact.join(":")
-      end
+      ENV['RUBYLIB'] = libdir if File.file?(File.join(libdir, "fiddle/import.rb"))
 
       assert_in_out_err(%w[--debug --disable=gems -rfiddle/import], 'p Fiddle::Importer', ['Fiddle::Importer'])
     ensure

--- a/test/fiddle/test_import.rb
+++ b/test/fiddle/test_import.rb
@@ -149,7 +149,10 @@ module Fiddle
     end
 
     def test_no_message_with_debug
-      assert_in_out_err(%w[--debug --disable=gems -rfiddle/import], 'p Fiddle::Importer', ['Fiddle::Importer'])
+      Bundler.with_clean_env do
+        libdir = File.expand_path('../../../lib', __FILE__)
+        assert_in_out_err(%W[--debug --disable=gems -I#{libdir} -rfiddle/import], 'p Fiddle::Importer', ['Fiddle::Importer'])
+      end
     end
   end
 end if defined?(Fiddle)

--- a/test/fiddle/test_import.rb
+++ b/test/fiddle/test_import.rb
@@ -149,10 +149,21 @@ module Fiddle
     end
 
     def test_no_message_with_debug
-      Bundler.with_clean_env do
-        libdir = File.expand_path('../../../lib', __FILE__)
-        assert_in_out_err(%W[--debug --disable=gems -I#{libdir} -rfiddle/import], 'p Fiddle::Importer', ['Fiddle::Importer'])
+      # disable bundler
+      orig_RUBYOPT = ENV['RUBYOPT']
+      ENV['RUBYOPT'] = orig_RUBYOPT.gsub(%r|-rbundler/setup|, '') if orig_RUBYOPT
+
+      # load development fiddle instead of bundled one
+      orig_RUBYLIB = ENV['RUBYLIB']
+      libdir = File.expand_path('../../../lib', __FILE__)
+      if File.file?(File.join(libdir, "fiddle/import.rb"))
+        ENV['RUBYLIB'] = [libdir, orig_RUBYLIB].compact.join(":")
       end
+
+      assert_in_out_err(%w[--debug --disable=gems -rfiddle/import], 'p Fiddle::Importer', ['Fiddle::Importer'])
+    ensure
+      ENV['RUBYLIB'] = orig_RUBYLIB
+      ENV['RUBYOPT'] = orig_RUBYOPT
     end
   end
 end if defined?(Fiddle)


### PR DESCRIPTION
This commit fixes the following failure:

```
  1) Failure:
Fiddle::TestImport#test_no_message_with_debug [/Users/mrkn/src/github.com/ruby/fiddle/test/fiddle/test_import.rb:152]:

1. [2/2] Assertion for "stderr"
   | <[]> expected but was
   | <["Exception `NameError' at /Users/mrkn/.rbenv/versions/2.5.1/lib/ruby/2.5.0/fiddle/import.rb:157 - uninitialized constant Fiddle::Function::STDCALL"]>.
```