### PR TITLE
Add support for nested structs

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ StudentDetail = struct [
 ]
 ```
 
-The position of a hash (and the order of the keys in the hash, in the case of a hash with multiple values), dictate the offsets of the nested struct in memory. For example, the following are both syntactically valid but will lay out the data in the nested structs differently in memory:
+The position of a hash (and the order of the keys in the hash, in the case of a hash with multiple entries), dictate the offsets of the nested struct in memory. The following examples are both syntactically valid but will lay out the structs differently in memory:
 
 ```ruby
 # order of members in memory: position, id, dimensions

--- a/README.md
+++ b/README.md
@@ -42,6 +42,57 @@ floor = Fiddle::Function.new(
 puts floor.call(3.14159) #=> 3.0
 ```
 
+### Nested Structs
+
+You can use hashes to create nested structs, where the hash keys are member names and the values are the nested structs:
+
+```ruby
+StudentCollegeDetail = struct [
+  'int college_id',
+  'char college_name[50]'
+]
+
+StudentDetail = struct [
+  'int id',
+  'char name[20]',
+  { clg_data: StudentCollegeDetail }
+]
+```
+
+You can also specify an anonymous nested struct, like so:
+
+```ruby
+StudentDetail = struct [
+  'int id',
+  'char name[20]',
+  {
+    clg_data: struct([
+                      'int college_id',
+                      'char college_name[50]'
+                    ])
+  }
+]
+```
+
+The position of a hash (and the order of the keys in the hash, in the case of a hash with multiple values), dictate the offsets of the nested struct in memory. For example, the following are both syntactically valid but will lay out the data in the nested structs differently in memory:
+
+```ruby
+# order of members in memory: position, id, dimensions
+Rect = struct [ { position: struct(['float x', 'float y']) },
+                'int id',
+                { dimensions: struct(['float w', 'float h']) }
+              ]
+
+# order of members in memory: id, position, dimensions
+Rect = struct [ 'int id',
+                {
+                  position: struct(['float x', 'float y']),
+                  dimensions: struct(['float w', 'float h'])
+                }
+              ]
+```
+
+
 ## Development
 
 After checking out the repo, run `bin/setup` to install dependencies. Then, run `rake test` to run the tests. You can also run `bin/console` for an interactive prompt that will allow you to experiment.

--- a/ext/fiddle/fiddle.c
+++ b/ext/fiddle/fiddle.c
@@ -47,8 +47,9 @@ static VALUE
 rb_fiddle_malloc(VALUE self, VALUE size)
 {
     void *ptr;
-
-    ptr = (void*)ruby_xmalloc(NUM2SIZET(size));
+    size_t sizet = NUM2SIZET(size);
+    ptr = (void*)ruby_xmalloc(sizet);
+    memset(ptr, 0, sizet);
     return PTR2NUM(ptr);
 }
 

--- a/ext/fiddle/pointer.c
+++ b/ext/fiddle/pointer.c
@@ -632,6 +632,27 @@ rb_fiddle_ptr_size_get(VALUE self)
 }
 
 /*
+ * call-seq: memcpy
+ *
+ * Copies the contents of the given pointer into this one. Will copy up to the
+ * allocated size of the given pointer or the allocated size of this one,
+ * whichever is smaller (to prevent overflow).
+ *
+ * Returns the number of bytes actually copied.
+ */
+static VALUE
+rb_fiddle_ptr_memcpy(VALUE self, VALUE other)
+{
+    long self_size  = NUM2LONG(rb_funcall(self,  rb_intern("size"), 0));
+    long other_size = NUM2LONG(rb_funcall(other, rb_intern("size"), 0));
+    void *self_ptr  = NUM2PTR(rb_fiddle_ptr_to_i(self));
+    void *other_ptr = NUM2PTR(rb_fiddle_ptr_to_i(other));
+    long size = self_size > other_size ? other_size : self_size;
+    memcpy(self_ptr, other_ptr, size);
+    return LONG2NUM(size);
+}
+
+/*
  * call-seq:
  *    Fiddle::Pointer[val]         => cptr
  *    to_ptr(val)  => cptr
@@ -713,6 +734,7 @@ Init_fiddle_pointer(void)
     rb_define_method(rb_cPointer, "[]=", rb_fiddle_ptr_aset, -1);
     rb_define_method(rb_cPointer, "size", rb_fiddle_ptr_size_get, 0);
     rb_define_method(rb_cPointer, "size=", rb_fiddle_ptr_size_set, 1);
+    rb_define_method(rb_cPointer, "memcpy", rb_fiddle_ptr_memcpy, 1);
 
     /*  Document-const: NULL
      *

--- a/lib/fiddle/cparser.rb
+++ b/lib/fiddle/cparser.rb
@@ -38,7 +38,7 @@ module Fiddle
       elsif signature.kind_of?(Hash)
         signature = [signature]
       elsif signature.respond_to?(:types) && signature.respond_to?(:members)
-        return signature.types, signature.members
+        return signature.types, signature.members, signature.entity_class
       end
       mems = []
       tys  = []
@@ -55,8 +55,11 @@ module Fiddle
             structure_parsed  = parse_struct_signature(struct_signature, tymap)
             structure_types   = structure_parsed[0]
             structure_members = structure_parsed[1]
+            structure_klass   = structure_parsed[2]
+            ty = [structure_types, structure_count]
+            ty << structure_klass if structure_klass
             mems.push([structure_name.to_s, structure_members])
-            tys.push([structure_types, structure_count])
+            tys.push(ty)
           end
         when /^[\w\*\s]+[\*\s](\w+)$/
           mems.push($1)

--- a/lib/fiddle/cparser.rb
+++ b/lib/fiddle/cparser.rb
@@ -37,6 +37,8 @@ module Fiddle
         signature = split_arguments(signature, /[,;]/)
       elsif signature.kind_of?(Hash)
         signature = [signature]
+      elsif signature.respond_to?(:types) && signature.respond_to?(:members)
+        return signature.types, signature.members
       end
       mems = []
       tys  = []

--- a/lib/fiddle/struct.rb
+++ b/lib/fiddle/struct.rb
@@ -92,8 +92,10 @@ module Fiddle
         define_method(:[]=) { |*args| @entity.send(:[]=, *args) }
         define_method(:to_ptr){ @entity }
         define_method(:to_i){ @entity.to_i }
+        define_method(:offset_of) { |*args| @entity.offset_of(*args) }
         define_singleton_method(:types) { types }
         define_singleton_method(:members) { members }
+        define_singleton_method(:offset_of) { |mbr| klass.entity_class.compute_offset(types, members, mbr) }
         members.each{|name|
           if name.kind_of?(Array) # name is a nested struct
             next if method_defined?(name[0])
@@ -136,6 +138,15 @@ module Fiddle
       max
     end
 
+    def CStructEntity.compute_offset(types, members, mbr)
+      members.each_with_index do |m, idx|
+        if (m.kind_of?(Array) ? m[0] : m) == mbr.to_s
+          return idx == 0 ? 0 : CStructEntity.size(types[0...idx])
+        end
+      end
+      raise(ArgumentError, "no such member: #{mbr}")
+    end
+
     # Allocates a C struct with the +types+ provided.
     #
     # When the instance is garbage collected, the C function +func+ is called.
@@ -154,12 +165,12 @@ module Fiddle
     def CStructEntity.size(types)
       offset = 0
 
-      max_align = types.map { |type, count = 1|
+      max_align = types.map { |type, count = 1, klass = CStructEntity|
         last_offset = offset
 
         if type.kind_of?(Array) # type is a nested array representing a nested struct
-          align = CStructEntity.alignment(type)
-          total_size = CStructEntity.size(type)
+          align = klass.alignment(type)
+          total_size = klass.size(type)
           offset = PackInfo.align(last_offset, align) +
                   (total_size * (count || 1))
         else
@@ -197,7 +208,7 @@ module Fiddle
           entity_class = CStructBuilder.create(CStruct, ty[0], members[idx][1])
           @nested_structs[member] ||= if ty[1]
             NestedStructArray.new(ty[1].times.map do |i|
-              entity_class.new(@addr + @offset[idx] + i * CStructEntity.size(ty[0]))
+              entity_class.new(@addr + @offset[idx] + i * (ty[2] || CStructEntity).size(ty[0]))
             end)
           else
             entity_class.new(@addr + @offset[idx])
@@ -212,11 +223,11 @@ module Fiddle
       @offset = []
       offset = 0
 
-      max_align = types.map { |type, count = 1|
+      max_align = types.map { |type, count = 1, klass = CStructEntity|
         orig_offset = offset
         if type.kind_of?(Array) # type is a nested array representing a nested struct
-          align = CStructEntity.alignment(type)
-          total_size = CStructEntity.size(type)
+          align = klass.alignment(type)
+          total_size = klass.size(type)
           offset = PackInfo.align(orig_offset, align)
           @offset << offset
           offset += (total_size * (count || 1))
@@ -231,6 +242,11 @@ module Fiddle
       }.max
 
       @size = PackInfo.align(offset, max_align)
+    end
+
+    def offset_of(mbr)
+      idx = @members.index(mbr.to_s) || raise(ArgumentError, "no such member: #{mbr}")
+      @offset[idx]
     end
 
     # Fetch struct member +name+ if only one argument is specified. If two
@@ -268,10 +284,11 @@ module Fiddle
       when Array
         case ty[0]
         when TYPE_VOIDP
-          val = val.collect{|v| Pointer.new(v)}
+          val = val.collect{|v| v = Pointer.new(v); v.size = SIZEOF_VOIDP; v }
         end
       when TYPE_VOIDP
         val = Pointer.new(val[0])
+        val.size = SIZEOF_VOIDP
       else
         val = val[0]
       end
@@ -335,6 +352,11 @@ module Fiddle
   class CUnionEntity < CStructEntity
     include PackInfo
 
+    def CUnionEntity.compute_offset(types, members, mbr)
+      # all members begin at offset 0
+      0
+    end
+
     # Allocates a C union the +types+ provided.
     #
     # When the instance is garbage collected, the C function +func+ is called.
@@ -351,9 +373,9 @@ module Fiddle
     #       Fiddle::TYPE_CHAR,
     #       Fiddle::TYPE_VOIDP ]) #=> 8
     def CUnionEntity.size(types)
-      types.map { |type, count = 1|
+      types.map { |type, count = 1, klass = CStructEntity|
         if type.kind_of?(Array) # type is a nested array representing a nested struct
-          CStructEntity.size(type) * (count || 1)
+          klass.size(type) * (count || 1)
         else
           PackInfo::SIZE_MAP[type] * count
         end

--- a/lib/fiddle/struct.rb
+++ b/lib/fiddle/struct.rb
@@ -63,6 +63,8 @@ module Fiddle
         }
         define_method(:to_ptr){ @entity }
         define_method(:to_i){ @entity.to_i }
+        define_singleton_method(:types) { types }
+        define_singleton_method(:members) { members }
         members.each{|name|
           if name.kind_of?(Array) # name is a nested struct
             next if method_defined?(name[0])

--- a/lib/fiddle/struct.rb
+++ b/lib/fiddle/struct.rb
@@ -96,6 +96,19 @@ module Fiddle
     include PackInfo
     include ValueUtil
 
+    def CStructEntity.alignment(types)
+      max = 1
+      types.each do |type, count = 1|
+        if type.kind_of?(Array) # nested struct
+          n = CStructEntity.alignment(type)
+        else
+          n = ALIGN_MAP[type]
+        end
+        max = n if n > max
+      end
+      max
+    end
+
     # Allocates a C struct with the +types+ provided.
     #
     # When the instance is garbage collected, the C function +func+ is called.
@@ -118,9 +131,10 @@ module Fiddle
         last_offset = offset
 
         if type.kind_of?(Array) # type is a nested array representing a nested struct
-          align = CStructEntity.size(type)
+          align = CStructEntity.alignment(type)
+          total_size = CStructEntity.size(type)
           offset = PackInfo.align(last_offset, align) +
-                  (align * (count || 1))
+                  (total_size * (count || 1))
         else
           align = PackInfo::ALIGN_MAP[type]
           offset = PackInfo.align(last_offset, align) +
@@ -174,10 +188,11 @@ module Fiddle
       max_align = types.map { |type, count = 1|
         orig_offset = offset
         if type.kind_of?(Array) # type is a nested array representing a nested struct
-          align = CStructEntity.size(type)
+          align = CStructEntity.alignment(type)
+          total_size = CStructEntity.size(type)
           offset = PackInfo.align(orig_offset, align)
           @offset << offset
-          offset += (align * (count || 1))
+          offset += (total_size * (count || 1))
         else
           align = ALIGN_MAP[type]
           offset = PackInfo.align(orig_offset, align)

--- a/lib/fiddle/struct.rb
+++ b/lib/fiddle/struct.rb
@@ -27,6 +27,33 @@ module Fiddle
     end
   end
 
+  # Wrapper for arrays within a struct
+  class StructArray < Array
+    include ValueUtil
+
+    def initialize(ptr, type, initial_values)
+      @ptr = ptr
+      @type = type
+      @align = PackInfo::ALIGN_MAP[type]
+      @size = Fiddle::PackInfo::SIZE_MAP[type]
+      @pack_format = Fiddle::PackInfo::PACK_MAP[type]
+      super(initial_values.collect { |v| unsigned_value(v, type) })
+    end
+
+    def to_ptr
+      @ptr
+    end
+
+    def []=(index, value)
+      if index < 0 || index >= size
+        raise RangeError, 'index %d outside of array bounds 0...%d' % [index, size]
+      end
+
+      to_ptr[index * @align, @size] = [value].pack(@pack_format)
+      super(index, value)
+    end
+  end
+
   # Used to construct C classes (CUnion, CStruct, etc)
   #
   # Fiddle::Importer#struct and Fiddle::Importer#union wrap this functionality in an
@@ -251,7 +278,7 @@ module Fiddle
       if( ty.is_a?(Integer) && (ty < 0) )
         return unsigned_value(val, ty)
       elsif( ty.is_a?(Array) && (ty[0] < 0) )
-        return val.collect{|v| unsigned_value(v,ty[0])}
+        return StructArray.new(self + @offset[idx], ty[0], val)
       else
         return val
       end

--- a/lib/fiddle/struct.rb
+++ b/lib/fiddle/struct.rb
@@ -283,7 +283,11 @@ module Fiddle
     #       Fiddle::TYPE_VOIDP ]) #=> 8
     def CUnionEntity.size(types)
       types.map { |type, count = 1|
-        PackInfo::SIZE_MAP[type] * count
+        if type.kind_of?(Array) # type is a nested array representing a nested struct
+          CStructEntity.size(type) * (count || 1)
+        else
+          PackInfo::SIZE_MAP[type] * count
+        end
       }.max
     end
 

--- a/lib/fiddle/struct.rb
+++ b/lib/fiddle/struct.rb
@@ -190,7 +190,9 @@ module Fiddle
     end
 
     # Fetch struct member +name+
-    def [](name)
+    def [](*args)
+      return super(*args) if args.size > 1
+      name = args[0]
       idx = @members.index(name)
       if( idx.nil? )
         raise(ArgumentError, "no such member: #{name}")
@@ -228,7 +230,9 @@ module Fiddle
     end
 
     # Set struct member +name+, to value +val+
-    def []=(name, val)
+    def []=(*args)
+      return super(*args) if args.size > 2
+      name, val = *args
       idx = @members.index(name)
       if( idx.nil? )
         raise(ArgumentError, "no such member: #{name}")

--- a/lib/fiddle/struct.rb
+++ b/lib/fiddle/struct.rb
@@ -20,6 +20,13 @@ module Fiddle
     end
   end
 
+  # Wrapper for arrays of structs within a struct
+  class NestedStructArray < Array
+    def []=(index, value)
+      self[index].to_ptr.memcpy(value.to_ptr)
+    end
+  end
+
   # Used to construct C classes (CUnion, CStruct, etc)
   #
   # Fiddle::Importer#struct and Fiddle::Importer#union wrap this functionality in an
@@ -57,6 +64,10 @@ module Fiddle
         define_method(:to_ptr){ @entity }
         define_method(:to_i){ @entity.to_i }
         members.each{|name|
+          if name.kind_of?(Array) # name is a nested struct
+            next if method_defined?(name[0])
+            name = name[0]
+          end
           define_method(name){ @entity[name] }
           define_method(name + "="){|val| @entity[name] = val }
         }
@@ -102,9 +113,15 @@ module Fiddle
       max_align = types.map { |type, count = 1|
         last_offset = offset
 
-        align = PackInfo::ALIGN_MAP[type]
-        offset = PackInfo.align(last_offset, align) +
-                 (PackInfo::SIZE_MAP[type] * count)
+        if type.kind_of?(Array) # type is a nested array representing a nested struct
+          align = CStructEntity.size(type)
+          offset = PackInfo.align(last_offset, align) +
+                  (align * (count || 1))
+        else
+          align = PackInfo::ALIGN_MAP[type]
+          offset = PackInfo.align(last_offset, align) +
+                   (PackInfo::SIZE_MAP[type] * count)
+        end
 
         align
       }.max
@@ -118,13 +135,30 @@ module Fiddle
     #
     # See also Fiddle::Pointer.new
     def initialize(addr, types, func = nil)
+      @addr = addr
       set_ctypes(types)
       super(addr, @size, func)
     end
 
     # Set the names of the +members+ in this C struct
     def assign_names(members)
-      @members = members
+      @members = members.map { |member| member.kind_of?(Array) ? member[0] : member }
+
+      @nested_structs = {}
+      @ctypes.each_with_index do |ty, idx|
+        if ty.kind_of?(Array) && ty[0].kind_of?(Array)
+          member = members[idx]
+          member = member[0] if member.kind_of?(Array)
+          entity_class = CStructBuilder.create(CStruct, ty[0], members[idx][1])
+          @nested_structs[member] ||= if ty[1]
+            NestedStructArray.new(ty[1].times.map do |i|
+              entity_class.new(@addr + @offset[idx] + i * CStructEntity.size(ty[0]))
+            end)
+          else
+            entity_class.new(@addr + @offset[idx])
+          end
+        end
+      end
     end
 
     # Calculates the offsets and sizes for the given +types+ in the struct.
@@ -135,12 +169,17 @@ module Fiddle
 
       max_align = types.map { |type, count = 1|
         orig_offset = offset
-        align = ALIGN_MAP[type]
-        offset = PackInfo.align(orig_offset, align)
-
-        @offset << offset
-
-        offset += (SIZE_MAP[type] * count)
+        if type.kind_of?(Array) # type is a nested array representing a nested struct
+          align = CStructEntity.size(type)
+          offset = PackInfo.align(orig_offset, align)
+          @offset << offset
+          offset += (align * (count || 1))
+        else
+          align = ALIGN_MAP[type]
+          offset = PackInfo.align(orig_offset, align)
+          @offset << offset
+          offset += (SIZE_MAP[type] * (count || 1))
+        end
 
         align
       }.max
@@ -156,7 +195,11 @@ module Fiddle
       end
       ty = @ctypes[idx]
       if( ty.is_a?(Array) )
-        r = super(@offset[idx], SIZE_MAP[ty[0]] * ty[1])
+        if ty.first.kind_of?(Array)
+          return @nested_structs[name]
+        else
+          r = super(@offset[idx], SIZE_MAP[ty[0]] * ty[1])
+        end
       else
         r = super(@offset[idx], SIZE_MAP[ty.abs])
       end
@@ -187,6 +230,16 @@ module Fiddle
       idx = @members.index(name)
       if( idx.nil? )
         raise(ArgumentError, "no such member: #{name}")
+      end
+      if @nested_structs[name]
+        if @nested_structs[name].kind_of?(Array)
+          val.size.times do |i|
+            @nested_structs[name][i].to_ptr.memcpy(val[i].to_ptr)
+          end
+        else
+          @nested_structs[name].to_ptr.memcpy(val.to_ptr)
+        end
+        return
       end
       ty  = @ctypes[idx]
       packer = Packer.new([ty])

--- a/test/fiddle/test_cparser.rb
+++ b/test/fiddle/test_cparser.rb
@@ -76,6 +76,27 @@ module Fiddle
       assert_equal [[[TYPE_CHAR,80],[TYPE_INT,5]], ['buffer','x']], parse_struct_signature(['char buffer[80]', 'int[5] x'])
     end
 
+    def test_struct_nested_struct
+      assert_equal [[TYPE_INT, [[TYPE_INT, TYPE_CHAR], nil]], ['x', ['inner', ['i', 'c']]]], parse_struct_signature(['int x', {inner: ['int i', 'char c']}])
+    end
+
+    def test_struct_double_nested_struct
+      assert_equal [[TYPE_INT, [[TYPE_INT, [[TYPE_INT, TYPE_CHAR], nil]], nil]], ['x', ['outer', ['y', ['inner', ['i', 'c']]]]]],
+                   parse_struct_signature(['int x', {outer: ['int y', { inner: ['int i', 'char c'] }]}])
+    end
+
+    def test_struct_nested_struct_array
+      assert_equal [[TYPE_INT, [[TYPE_INT, TYPE_CHAR], 2]], ['x', ['inner', ['i', 'c']]]], parse_struct_signature(['int x', {'inner[2]' => ['int i', 'char c']}])
+    end
+
+    def test_struct_double_nested_struct_inner_array
+      assert_equal [[[[TYPE_INT, [[TYPE_INT, TYPE_CHAR], 2]], nil]], [['outer', ['x', ['inner', ['i', 'c']]]]]], parse_struct_signature(outer: ['int x', { 'inner[2]' => ['int i', 'char c'] }])
+    end
+
+    def test_struct_double_nested_struct_outer_array
+      assert_equal [[TYPE_INT, [[[[TYPE_INT, TYPE_CHAR], nil]], 2]], ['x', ['outer', [['inner', ['i', 'c']]]]]], parse_struct_signature(['int x', {'outer[2]' => { inner: ['int i', 'char c'] }}])
+    end
+
     def test_struct_array_str
       assert_equal [[[TYPE_CHAR,80],[TYPE_INT,5]], ['buffer','x']], parse_struct_signature('char buffer[80], int[5] x')
     end

--- a/test/fiddle/test_import.rb
+++ b/test/fiddle/test_import.rb
@@ -209,6 +209,35 @@ module Fiddle
       refute_equal(  0, s.mouse.x)
     end
 
+    def test_size_of_struct_accessor_returning_void_pointer()
+      s = Fiddle::Importer.struct(['void *x', 'void *y[2]']).malloc
+      assert_equal Fiddle::SIZEOF_VOIDP, s['x'].size
+      assert_equal Fiddle::SIZEOF_VOIDP, s['y'][0].size
+    end
+
+    def test_struct_size_and_offset_of_nested_unions()
+      a = Fiddle::Importer.union ['float f[4]', 'int i[2]']
+      b = Fiddle::Importer.struct ['float x', 'int y']
+      c = Fiddle::Importer.struct [ a: a, b: b ]
+
+      assert_equal                        0, a.offset_of(:f)
+      assert_equal                        0, a.offset_of(:i)
+      assert_equal                        0, b.offset_of(:x)
+      assert_equal     Fiddle::SIZEOF_FLOAT, b.offset_of(:y)
+      assert_equal                        0, c.offset_of(:a)
+      assert_equal 4 * Fiddle::SIZEOF_FLOAT, c.offset_of(:b)
+
+      assert_equal a.offset_of(:f), a.malloc.offset_of(:f)
+      assert_equal a.offset_of(:i), a.malloc.offset_of(:i)
+      assert_equal b.offset_of(:x), b.malloc.offset_of(:x)
+      assert_equal b.offset_of(:y), b.malloc.offset_of(:y)
+      assert_equal c.offset_of(:a), c.malloc.offset_of(:a)
+      assert_equal c.offset_of(:b), c.malloc.offset_of(:b)
+
+      assert_equal Fiddle::SIZEOF_FLOAT * 4 + Fiddle::SIZEOF_INT * 2,
+                   c.size
+    end
+
     def test_struct_array_assignment()
       instance = Fiddle::Importer.struct(["unsigned int stages[1]"]).malloc
       instance.stages[0] = 1024

--- a/test/fiddle/test_import.rb
+++ b/test/fiddle/test_import.rb
@@ -163,6 +163,16 @@ module Fiddle
       assert_equal LIBC::UnionNestedStruct.size, event_union.size
     end
 
+    def test_nested_struct_alignment_is_not_its_size()
+      inner = Fiddle::Importer.struct(['int x', 'int y', 'int z', 'int w'])
+      outer = Fiddle::Importer.struct(['char a', { 'nested' => inner }, 'char b'])
+      instance = outer.malloc
+      offset = instance.to_ptr.instance_variable_get(:"@offset")
+      assert_equal Fiddle::SIZEOF_INT * 5, offset.last
+      assert_equal Fiddle::SIZEOF_INT * 6, outer.size
+      assert_equal instance.to_ptr.size, outer.size
+    end
+
     def test_struct_nested_struct_members()
       s = LIBC::StructNestedStruct.malloc
       s.vertices[0].position.x = 1

--- a/test/fiddle/test_import.rb
+++ b/test/fiddle/test_import.rb
@@ -36,6 +36,16 @@ module Fiddle
       "char c",
       "unsigned char buff[7]",
     ]
+    NestedStruct = struct [
+      {
+        "vertices[2]" => {
+          position: [ "float x", "float y", "float z" ],
+          texcoord: [ "float u", "float v" ]
+        },
+        object:  [ "int id" ]
+      },
+      "int id"
+    ]
 
     CallCallback = bind("void call_callback(void*, void*)"){ | ptr1, ptr2|
       f = Function.new(ptr1.to_i, [TYPE_VOIDP], TYPE_VOID)
@@ -65,6 +75,7 @@ module Fiddle
       assert_equal(LIBC::MyStruct.size(), LIBC.sizeof(LIBC::MyStruct))
       assert_equal(LIBC::MyStruct.size(), LIBC.sizeof(LIBC::MyStruct.malloc()))
       assert_equal(SIZEOF_LONG_LONG, LIBC.sizeof("long long")) if defined?(SIZEOF_LONG_LONG)
+      assert_equal(LIBC::NestedStruct.size(), LIBC.sizeof(LIBC::NestedStruct))
     end
 
     Fiddle.constants.grep(/\ATYPE_(?!VOID\z)(.*)/) do
@@ -105,6 +116,92 @@ module Fiddle
 
       ary = LIBC.value('int[3]', [0,1,2])
       assert_equal([0,1,2], ary.value)
+    end
+
+    def test_nested_struct_members()
+      s = LIBC::NestedStruct.malloc
+      s.vertices[0].position.x = 1
+      s.vertices[0].position.y = 2
+      s.vertices[0].position.z = 3
+      s.vertices[0].texcoord.u = 4
+      s.vertices[0].texcoord.v = 5
+      s.vertices[1].position.x = 6
+      s.vertices[1].position.y = 7
+      s.vertices[1].position.z = 8
+      s.vertices[1].texcoord.u = 9
+      s.vertices[1].texcoord.v = 10
+      s.object.id              = 100
+      s.id                     = 101
+      assert_equal(1,   s.vertices[0].position.x)
+      assert_equal(2,   s.vertices[0].position.y)
+      assert_equal(3,   s.vertices[0].position.z)
+      assert_equal(4,   s.vertices[0].texcoord.u)
+      assert_equal(5,   s.vertices[0].texcoord.v)
+      assert_equal(6,   s.vertices[1].position.x)
+      assert_equal(7,   s.vertices[1].position.y)
+      assert_equal(8,   s.vertices[1].position.z)
+      assert_equal(9,   s.vertices[1].texcoord.u)
+      assert_equal(10,  s.vertices[1].texcoord.v)
+      assert_equal(100, s.object.id)
+      assert_equal(101, s.id)
+    end
+
+    def test_nested_struct_replace_array_element()
+      s = LIBC::NestedStruct.malloc
+      s.vertices[0].position.x = 5
+
+      vertex_struct = Fiddle::Importer.struct [{
+        position: [ "float x", "float y", "float z" ],
+        texcoord: [ "float u", "float v" ]
+      }]
+      vertex = vertex_struct.malloc
+      vertex.position.x = 100
+      s.vertices[0] = vertex
+
+      # make sure element was copied by value, but things like memory address
+      # should not be changed
+      assert_equal(100,              s.vertices[0].position.x)
+      refute_equal(vertex.object_id, s.vertices[0].object_id)
+      refute_equal(vertex.to_ptr,    s.vertices[0].to_ptr)
+    end
+
+    def test_nested_struct_replace_entire_array()
+      s = LIBC::NestedStruct.malloc
+      vertex_struct = Fiddle::Importer.struct [{
+        position: [ "float x", "float y", "float z" ],
+        texcoord: [ "float u", "float v" ]
+      }]
+
+      different_struct_same_size = Fiddle::Importer.struct [{
+        a: [ 'float i', 'float j', 'float k' ],
+        b: [ 'float l', 'float m' ]
+      }]
+
+      same = [vertex_struct.malloc, vertex_struct.malloc]
+      same[0].position.x = 1; same[1].position.x = 6
+      same[0].position.y = 2; same[1].position.y = 7
+      same[0].position.z = 3; same[1].position.z = 8
+      same[0].texcoord.u = 4; same[1].texcoord.u = 9
+      same[0].texcoord.v = 5; same[1].texcoord.v = 10
+      s.vertices = same
+      assert_equal(1, s.vertices[0].position.x); assert_equal(6,  s.vertices[1].position.x)
+      assert_equal(2, s.vertices[0].position.y); assert_equal(7,  s.vertices[1].position.y)
+      assert_equal(3, s.vertices[0].position.z); assert_equal(8,  s.vertices[1].position.z)
+      assert_equal(4, s.vertices[0].texcoord.u); assert_equal(9,  s.vertices[1].texcoord.u)
+      assert_equal(5, s.vertices[0].texcoord.v); assert_equal(10, s.vertices[1].texcoord.v)
+
+      different = [different_struct_same_size.malloc, different_struct_same_size.malloc]
+      different[0].a.i = 11; different[1].a.i = 16
+      different[0].a.j = 12; different[1].a.j = 17
+      different[0].a.k = 13; different[1].a.k = 18
+      different[0].b.l = 14; different[1].b.l = 19
+      different[0].b.m = 15; different[1].b.m = 20
+      s.vertices = different
+      assert_equal(11, s.vertices[0].position.x); assert_equal(16, s.vertices[1].position.x)
+      assert_equal(12, s.vertices[0].position.y); assert_equal(17, s.vertices[1].position.y)
+      assert_equal(13, s.vertices[0].position.z); assert_equal(18, s.vertices[1].position.z)
+      assert_equal(14, s.vertices[0].texcoord.u); assert_equal(19, s.vertices[1].texcoord.u)
+      assert_equal(15, s.vertices[0].texcoord.v); assert_equal(20, s.vertices[1].texcoord.v)
     end
 
     def test_struct()

--- a/test/fiddle/test_import.rb
+++ b/test/fiddle/test_import.rb
@@ -131,6 +131,14 @@ module Fiddle
       assert_equal([0,1,2], ary.value)
     end
 
+    def test_struct_array_subscript_multiarg()
+      struct = Fiddle::Importer.struct([ 'int x' ]).malloc
+      assert_equal("\x00".b * Fiddle::SIZEOF_INT, struct.to_ptr[0, Fiddle::SIZEOF_INT])
+
+      struct.to_ptr[0, Fiddle::SIZEOF_INT] = "\x01".b * Fiddle::SIZEOF_INT
+      assert_equal 16843009, struct.x
+    end
+
     def test_nested_struct_reusing_other_structs()
       position_struct = Fiddle::Importer.struct([ 'float x', 'float y', 'float z' ])
       texcoord_struct = Fiddle::Importer.struct([ 'float u', 'float v' ])

--- a/test/fiddle/test_import.rb
+++ b/test/fiddle/test_import.rb
@@ -77,6 +77,16 @@ module Fiddle
       assert_match(/call dlload before/, err.message)
     end
 
+    def test_struct_memory_access
+      my_struct = Fiddle::Importer.struct(['int id']).malloc
+      my_struct['id'] = 1
+      my_struct[0, Fiddle::SIZEOF_INT] = "\x01".b * Fiddle::SIZEOF_INT
+      refute_equal 0, my_struct.id
+
+      my_struct.id = 0
+      assert_equal "\x00".b * Fiddle::SIZEOF_INT, my_struct[0, Fiddle::SIZEOF_INT]
+    end
+
     def test_malloc()
       s1 = LIBC::Timeval.malloc()
       s2 = LIBC::Timeval.malloc()

--- a/test/fiddle/test_import.rb
+++ b/test/fiddle/test_import.rb
@@ -118,6 +118,14 @@ module Fiddle
       assert_equal([0,1,2], ary.value)
     end
 
+    def test_nested_struct_reusing_other_structs()
+      position_struct = Fiddle::Importer.struct([ 'float x', 'float y', 'float z' ])
+      texcoord_struct = Fiddle::Importer.struct([ 'float u', 'float v' ])
+      vertex_struct   = Fiddle::Importer.struct(position: position_struct, texcoord: texcoord_struct)
+      mesh_struct     = Fiddle::Importer.struct([{"vertices[2]" => vertex_struct, object: [ "int id" ]}, "int id"])
+      assert_equal LIBC::NestedStruct.size, mesh_struct.size
+    end
+
     def test_nested_struct_members()
       s = LIBC::NestedStruct.malloc
       s.vertices[0].position.x = 1

--- a/test/fiddle/test_import.rb
+++ b/test/fiddle/test_import.rb
@@ -209,6 +209,16 @@ module Fiddle
       refute_equal(  0, s.mouse.x)
     end
 
+    def test_struct_array_assignment()
+      instance = Fiddle::Importer.struct(["unsigned int stages[1]"]).malloc
+      instance.stages[0] = 1024
+      assert_equal 1024, instance.stages[0]
+      assert_equal [1024].pack(Fiddle::PackInfo::PACK_MAP[-Fiddle::TYPE_INT]),
+                   instance.to_ptr[0, Fiddle::SIZEOF_INT]
+      assert_raise(RangeError) { instance.stages[-1] = 5 }
+      assert_raise(RangeError) { instance.stages[2] = 5 }
+    end
+
     def test_struct_nested_struct_replace_array_element()
       s = LIBC::StructNestedStruct.malloc
       s.vertices[0].position.x = 5

--- a/test/fiddle/test_pointer.rb
+++ b/test/fiddle/test_pointer.rb
@@ -32,6 +32,20 @@ module Fiddle
       assert_equal free.to_i, ptr.free.to_i
     end
 
+    def test_memcpy
+      ptr     = Pointer[Marshal.load(Marshal.dump("hello world"))]
+      smaller = Pointer[Marshal.load(Marshal.dump("1234567890"))]
+      same    = Pointer[Marshal.load(Marshal.dump("12345678901"))]
+      larger  = Pointer[Marshal.load(Marshal.dump("123456789012"))]
+
+      assert_equal(ptr.size - 1, smaller.memcpy(ptr))
+      assert_equal(ptr.size    , same.memcpy(ptr))
+      assert_equal(ptr.size    , larger.memcpy(ptr))
+      assert_equal("hello worl",   smaller.to_s)
+      assert_equal("hello world",  same.to_s)
+      assert_equal("hello world2", larger.to_s)
+    end
+
     def test_to_str
       str = Marshal.load(Marshal.dump("hello world"))
       ptr = Pointer[str]


### PR DESCRIPTION
This pull request does a few things. The main goal of the PR is to add support for nested structs and unions containing structs, as discussed in #12. I need this for a non-trivial project and have been using the nested struct code in numerous places within that project for several weeks now, so I am confident it is working properly. The syntax is a little strange, but works quite well, and is easy to learn. One could express the example given in #12 like so:

```ruby
StudentCollegeDetail = struct [
  'int college_id',
  'char college_name[50]'
]

StudentDetail = struct [
  'int id',
  'char name[20]',
  { clg_data: StudentCollegeDetail }
]
```

It is also possible to specify the nested struct in-line, by replacing `StudentCollegeDetail` with `struct([...])`, like so: 

```ruby
StudentDetail = struct [
  'int id',
  'char name[20]',
  {
    clg_data: struct([
                      'int college_id',
                      'char college_name[50]'
                    ])
  }
]
```

The hash does not need to appear last. In fact, its position in the list of members dictates the offset into the parent struct at which the nested struct appears, in order to play nicely with C structs. There can be multiple hashes, or a single hash with multiple keys/values, or any combination of these. The following examples are also valid syntax, but will result in the struct members being laid out at different offsets within the outer struct's memory:

```ruby
# order of members in memory: position, id, dimensions
Rect = struct [ { position: struct(['float x', 'float y']) },
                'int id',
                { dimensions: struct(['float w', 'float h']) }
              ]

# order of members in memory: id, position, dimensions (assuming ordered hash)
Rect = struct [ 'int id',
                {
                  position: struct(['float x', 'float y']),
                  dimensions: struct(['float w', 'float h'])
                }
              ]
```

Second: when calling `Fiddle.malloc`, the contents of the resulting memory were not initialized to 0 as they were when calling `Fiddle::Pointer.malloc`. This inconsistency caused me a few headaches so I decided to fix it.

Third: `CStructEntity` defines array set and get methods (`[]` / `[]=`), which is fine except that they override `Fiddle::Pointer#[]` and `Fiddle::Pointer#[]=` and do not handle the 3rd argument that the base class allows for. I found that if I wanted to access the underlying memory of a struct directly, instead of working with the struct members, I had no good way to do that. So I modified these methods to check for an additional argument, and if present, delegate that to `super` so that the underlying memory could be accessed / assigned directly.

Fourth: When a member of a struct is an array, `CStructEntity` was returning a temporary array containing those values. Assignment to that array became a no-op, which was confusing. I fixed this so that assignment to the returned array correctly updates the member within the struct. (Example: `a = struct(['int i[5]']).malloc; a.i[2] = 1; a.i[2] #=> 1`)

I am happy to move these changes into multiple pull requests, or back out an undesirable change, if needed.
