### PR TITLE
Use ffi_closure_free by default.

### DIFF
--- a/ext/fiddle/closure.c
+++ b/ext/fiddle/closure.c
@@ -13,25 +13,11 @@ typedef struct {
     ffi_type **argv;
 } fiddle_closure;
 
-#if defined(USE_FFI_CLOSURE_ALLOC)
-#elif defined(__OpenBSD__) || defined(__APPLE__) || defined(__linux__)
-# define USE_FFI_CLOSURE_ALLOC 0
-#elif defined(RUBY_LIBFFI_MODVERSION) && RUBY_LIBFFI_MODVERSION < 3000005 && \
-	(defined(__i386__) || defined(__x86_64__) || defined(_M_IX86) || defined(_M_AMD64))
-# define USE_FFI_CLOSURE_ALLOC 0
-#else
-# define USE_FFI_CLOSURE_ALLOC 1
-#endif
-
 static void
 dealloc(void * ptr)
 {
     fiddle_closure * cls = (fiddle_closure *)ptr;
-#if USE_FFI_CLOSURE_ALLOC
     ffi_closure_free(cls->pcl);
-#else
-    munmap(cls->pcl, sizeof(*cls->pcl));
-#endif
     if (cls->argv) xfree(cls->argv);
     xfree(cls);
 }
@@ -205,12 +191,7 @@ allocate(VALUE klass)
     VALUE i = TypedData_Make_Struct(klass, fiddle_closure,
 	    &closure_data_type, closure);
 
-#if USE_FFI_CLOSURE_ALLOC
     closure->pcl = ffi_closure_alloc(sizeof(ffi_closure), &closure->code);
-#else
-    closure->pcl = mmap(NULL, sizeof(ffi_closure), PROT_READ | PROT_WRITE,
-        MAP_ANON | MAP_PRIVATE, -1, 0);
-#endif
 
     return i;
 }
@@ -257,17 +238,8 @@ initialize(int rbargc, VALUE argv[], VALUE self)
     if (FFI_OK != result)
 	rb_raise(rb_eRuntimeError, "error prepping CIF %d", result);
 
-#if USE_FFI_CLOSURE_ALLOC
     result = ffi_prep_closure_loc(pcl, cif, callback,
 		(void *)self, cl->code);
-#else
-    result = ffi_prep_closure(pcl, cif, callback, (void *)self);
-    cl->code = (void *)pcl;
-    i = mprotect(pcl, sizeof(*pcl), PROT_READ | PROT_EXEC);
-    if (i) {
-	rb_sys_fail("mprotect");
-    }
-#endif
 
     if (FFI_OK != result)
 	rb_raise(rb_eRuntimeError, "error prepping closure %d", result);

--- a/ext/fiddle/extconf.rb
+++ b/ext/fiddle/extconf.rb
@@ -27,20 +27,20 @@ begin
     Dir.glob("#{$srcdir}/libffi-*/").each{|dir| FileUtils.rm_rf(dir)}
     extlibs.run(["--cache=#{cache_dir}", ext_dir])
   end
-  ver = bundle != false &&
+  libffi_dir = bundle != false &&
         Dir.glob("#{$srcdir}/libffi-*/")
         .map {|n| File.basename(n)}
         .max_by {|n| n.scan(/\d+/).map(&:to_i)}
-  unless ver
+  unless libffi_dir
     raise "missing libffi. Please install libffi."
   end
 
-  srcdir = "#{$srcdir}/#{ver}"
+  srcdir = "#{$srcdir}/#{libffi_dir}"
   ffi_header = 'ffi.h'
   libffi = Struct.new(*%I[dir srcdir builddir include lib a cflags ldflags opt arch]).new
-  libffi.dir = ver
+  libffi.dir = libffi_dir
   if $srcdir == "."
-    libffi.builddir = "#{ver}/#{RUBY_PLATFORM}"
+    libffi.builddir = "#{libffi_dir}/#{RUBY_PLATFORM}"
     libffi.srcdir = "."
   else
     libffi.builddir = libffi.dir

--- a/ext/fiddle/extconf.rb
+++ b/ext/fiddle/extconf.rb
@@ -7,8 +7,7 @@ bundle = enable_config('bundled-libffi')
 if ! bundle
   dir_config 'libffi'
 
-  pkg_config("libffi") and
-    ver = pkg_config("libffi", "modversion")
+  pkg_config("libffi")
 
   if have_header(ffi_header = 'ffi.h')
     true
@@ -52,7 +51,6 @@ begin
   libffi.a = "#{libffi.lib}/libffi_convenience.#{$LIBEXT}"
   nowarn = CONFIG.merge("warnflags"=>"")
   libffi.cflags = RbConfig.expand("$(CFLAGS)".dup, nowarn)
-  ver = ver[/libffi-(.*)/, 1]
 
   FileUtils.mkdir_p(libffi.dir)
   libffi.opt = CONFIG['configure_args'][/'(-C)'/, 1]
@@ -110,12 +108,6 @@ begin
     FileUtils.cp("#{srcdir}/src/x86/ffitarget.h", libffi.include, preserve: true)
   end
   $INCFLAGS << " -I" << libffi.include
-end
-
-if ver
-  ver = ver.gsub(/-rc\d+/, '') # If ver contains rc version, just ignored.
-  ver = (ver.split('.') + [0,0])[0,3]
-  $defs.push(%{-DRUBY_LIBFFI_MODVERSION=#{ '%d%03d%03d' % ver }})
 end
 
 have_header 'sys/mman.h'


### PR DESCRIPTION
TLDR; Set ```USE_FFI_CLOSURE_ALLOC=1``` by default for better compatibility and improved SELinux support [[3]]


Recently, we were trying to build Ruby 2.6 on RHEL8, but with the most recent version of libffi including patch for https://github.com/libffi/libffi/issues/470, we started to observe crashes on AArch64 such as:

~~~
... snip ...

making mjit_build_dir.so
/builddir/build/BUILD/ruby-2.6.3/.ext/common/fiddle/import.rb:317: [BUG] Segmentation fault at 0x0000000000000018
ruby 2.6.3p62 (2019-04-16 revision 67580) [aarch64-linux]
-- Control frame information -----------------------------------------------
c:0018 p:---- s:0103 e:000102 CFUNC  :initialize
c:0017 p:---- s:0100 e:000099 CFUNC  :new
c:0016 p:0047 s:0093 e:000092 METHOD /builddir/build/BUILD/ruby-2.6.3/.ext/common/fiddle/import.rb:317
c:0015 p:0111 s:0082 e:000081 METHOD /builddir/build/BUILD/ruby-2.6.3/.ext/common/fiddle/import.rb:198
c:0014 p:0107 s:0068 E:001b30 CLASS  /builddir/build/BUILD/ruby-2.6.3/test/fiddle/test_import.rb:25
c:0013 p:0007 s:0065 e:000064 CLASS  /builddir/build/BUILD/ruby-2.6.3/test/fiddle/test_import.rb:10
c:0012 p:0029 s:0062 e:000061 TOP    /builddir/build/BUILD/ruby-2.6.3/test/fiddle/test_import.rb:9 [FINISH]
c:0011 p:---- s:0059 e:000058 CFUNC  :require
c:0010 p:0060 s:0054 e:000053 BLOCK  /builddir/build/BUILD/ruby-2.6.3/test/lib/test/unit.rb:958 [FINISH]
c:0009 p:---- s:0048 e:000047 CFUNC  :each
c:0008 p:0031 s:0044 e:000043 METHOD /builddir/build/BUILD/ruby-2.6.3/test/lib/test/unit.rb:952
c:0007 p:0081 s:0036 e:000035 METHOD /builddir/build/BUILD/ruby-2.6.3/test/lib/test/unit.rb:64
c:0006 p:0020 s:0028 e:000027 METHOD /builddir/build/BUILD/ruby-2.6.3/test/lib/test/unit.rb:130
c:0005 p:0010 s:0022 e:000021 METHOD /builddir/build/BUILD/ruby-2.6.3/test/lib/test/unit.rb:1136
c:0004 p:0012 s:0017 e:000016 METHOD /builddir/build/BUILD/ruby-2.6.3/test/lib/test/unit.rb:1141
c:0003 p:0011 s:0013 e:000012 METHOD /builddir/build/BUILD/ruby-2.6.3/test/lib/test/unit.rb:1148
c:0002 p:0263 s:0008 E:001d28 EVAL   ./test/runner.rb:33 [FINISH]
c:0001 p:0000 s:0003 E:0004e0 (none) [FINISH]
-- Ruby level backtrace information ----------------------------------------
./test/runner.rb:33:in `<main>'
/builddir/build/BUILD/ruby-2.6.3/test/lib/test/unit.rb:1148:in `run'
/builddir/build/BUILD/ruby-2.6.3/test/lib/test/unit.rb:1141:in `run'
/builddir/build/BUILD/ruby-2.6.3/test/lib/test/unit.rb:1136:in `process_args'
/builddir/build/BUILD/ruby-2.6.3/test/lib/test/unit.rb:130:in `process_args'
/builddir/build/BUILD/ruby-2.6.3/test/lib/test/unit.rb:64:in `process_args'
/builddir/build/BUILD/ruby-2.6.3/test/lib/test/unit.rb:952:in `non_options'
/builddir/build/BUILD/ruby-2.6.3/test/lib/test/unit.rb:952:in `each'
/builddir/build/BUILD/ruby-2.6.3/test/lib/test/unit.rb:958:in `block in non_options'
/builddir/build/BUILD/ruby-2.6.3/test/lib/test/unit.rb:958:in `require'
/builddir/build/BUILD/ruby-2.6.3/test/fiddle/test_import.rb:9:in `<top (required)>'
/builddir/build/BUILD/ruby-2.6.3/test/fiddle/test_import.rb:10:in `<module:Fiddle>'
/builddir/build/BUILD/ruby-2.6.3/test/fiddle/test_import.rb:25:in `<module:LIBC>'
/builddir/build/BUILD/ruby-2.6.3/.ext/common/fiddle/import.rb:198:in `bind'
/builddir/build/BUILD/ruby-2.6.3/.ext/common/fiddle/import.rb:317:in `bind_function'
/builddir/build/BUILD/ruby-2.6.3/.ext/common/fiddle/import.rb:317:in `new'
/builddir/build/BUILD/ruby-2.6.3/.ext/common/fiddle/import.rb:317:in `initialize'
-- C level backtrace information -------------------------------------------
/builddir/build/BUILD/ruby-2.6.3/libruby.so.2.6.3(rb_print_backtrace+0x20) [0xffffbe6794f8] vm_dump.c:715
/builddir/build/BUILD/ruby-2.6.3/libruby.so.2.6.3(rb_vm_bugreport+0x8c) [0xffffbe679594] vm_dump.c:985
/builddir/build/BUILD/ruby-2.6.3/libruby.so.2.6.3(rb_bug_context+0xc4) [0xffffbe52bcac] error.c:609
/builddir/build/BUILD/ruby-2.6.3/libruby.so.2.6.3(sigsegv+0x4c) [0xffffbe6059fc] signal.c:998
linux-vdso.so.1(__kernel_rt_sigreturn+0x0) [0xffffbe7c066c]
[0xffffbb8b4398]
[0xffffbb8b5b74]
[0xffffbb8e3340]
/builddir/build/BUILD/ruby-2.6.3/libruby.so.2.6.3(rb_vm_call0+0x284) [0xffffbe66ec24] vm_eval.c:86
/builddir/build/BUILD/ruby-2.6.3/libruby.so.2.6.3(rb_class_s_new+0x30) [0xffffbe59eb30] object.c:2187
/builddir/build/BUILD/ruby-2.6.3/libruby.so.2.6.3(vm_call_cfunc+0x120) [0xffffbe6625b0] vm_insnhelper.c:1908
/builddir/build/BUILD/ruby-2.6.3/libruby.so.2.6.3(vm_call_method+0x68) [0xffffbe66cd18] vm_insnhelper.c:2369
/builddir/build/BUILD/ruby-2.6.3/libruby.so.2.6.3(vm_exec_core+0x128) [0xffffbe666710] insns.def:765
/builddir/build/BUILD/ruby-2.6.3/libruby.so.2.6.3(rb_vm_exec+0x1d4) [0xffffbe66b7ec] vm.c:1894
/builddir/build/BUILD/ruby-2.6.3/libruby.so.2.6.3(rb_load_internal0+0xe4) [0xffffbe5702d4] load.c:612
/builddir/build/BUILD/ruby-2.6.3/libruby.so.2.6.3(rb_require_internal+0x4e4) [0xffffbe571afc] load.c:1029
/builddir/build/BUILD/ruby-2.6.3/libruby.so.2.6.3(rb_require_safe+0x14) [0xffffbe571bb4] load.c:1075
/builddir/build/BUILD/ruby-2.6.3/libruby.so.2.6.3(vm_call_cfunc+0x120) [0xffffbe6625b0] vm_insnhelper.c:1908
/builddir/build/BUILD/ruby-2.6.3/libruby.so.2.6.3(vm_exec_core+0x128) [0xffffbe666710] insns.def:765
/builddir/build/BUILD/ruby-2.6.3/libruby.so.2.6.3(rb_vm_exec+0x1d4) [0xffffbe66b7ec] vm.c:1894
/builddir/build/BUILD/ruby-2.6.3/libruby.so.2.6.3(rb_yield+0x1f4) [0xffffbe67295c] vm.c:1021
/builddir/build/BUILD/ruby-2.6.3/libruby.so.2.6.3(rb_ary_each+0x3c) [0xffffbe4c427c] array.c:2086
/builddir/build/BUILD/ruby-2.6.3/libruby.so.2.6.3(vm_call_cfunc+0x120) [0xffffbe6625b0] vm_insnhelper.c:1908
/builddir/build/BUILD/ruby-2.6.3/libruby.so.2.6.3(vm_call_method+0x68) [0xffffbe66cd18] vm_insnhelper.c:2369
/builddir/build/BUILD/ruby-2.6.3/libruby.so.2.6.3(vm_exec_core+0x1bc) [0xffffbe6667a4] insns.def:750
/builddir/build/BUILD/ruby-2.6.3/libruby.so.2.6.3(rb_vm_exec+0x1d4) [0xffffbe66b7ec] vm.c:1894
/builddir/build/BUILD/ruby-2.6.3/libruby.so.2.6.3(ruby_exec_internal+0xd4) [0xffffbe52fc5c] eval.c:262
/builddir/build/BUILD/ruby-2.6.3/libruby.so.2.6.3(ruby_exec_node+0x1c) [0xffffbe531d0c] eval.c:326
/builddir/build/BUILD/ruby-2.6.3/libruby.so.2.6.3(ruby_run_node+0x38) [0xffffbe534418] eval.c:318
/builddir/build/BUILD/ruby-2.6.3/ruby(main+0x60) [0xaaaaaaaa0b80] ./main.c:42
RPM build errors:
-- Other runtime information -----------------------------------------------
* Loaded script: ./test/runner.rb
* Loaded features:
    0 enumerator.so
    1 thread.rb
    2 rational.so
    3 complex.so
    4 /builddir/build/BUILD/ruby-2.6.3/.ext/aarch64-linux/enc/encdb.so
    5 /builddir/build/BUILD/ruby-2.6.3/.ext/aarch64-linux/enc/trans/transdb.so
    6 /builddir/build/BUILD/ruby-2.6.3/rbconfig.rb
    7 /builddir/build/BUILD/ruby-2.6.3/lib/optparse.rb
    8 /builddir/build/BUILD/ruby-2.6.3/test/lib/leakchecker.rb
    9 /builddir/build/BUILD/ruby-2.6.3/test/lib/minitest/unit.rb
   10 /builddir/build/BUILD/ruby-2.6.3/lib/prettyprint.rb
   11 /builddir/build/BUILD/ruby-2.6.3/lib/pp.rb
   12 /builddir/build/BUILD/ruby-2.6.3/test/lib/test/unit/assertions.rb
   13 /builddir/build/BUILD/ruby-2.6.3/lib/open3.rb
   14 /builddir/build/BUILD/ruby-2.6.3/lib/timeout.rb
   15 /builddir/build/BUILD/ruby-2.6.3/test/lib/find_executable.rb
   16 /builddir/build/BUILD/ruby-2.6.3/.ext/aarch64-linux/rbconfig/sizeof.so
   17 /builddir/build/BUILD/ruby-2.6.3/test/lib/envutil.rb
   18 /builddir/build/BUILD/ruby-2.6.3/test/lib/test/unit/testcase.rb
   19 /builddir/build/BUILD/ruby-2.6.3/test/lib/test/unit.rb
   20 /builddir/build/BUILD/ruby-2.6.3/test/lib/tracepointchecker.rb
   21 /builddir/build/BUILD/ruby-2.6.3/test/lib/zombie_hunter.rb
   22 /builddir/build/BUILD/ruby-2.6.3/lib/delegate.rb
   23 /builddir/build/BUILD/ruby-2.6.3/lib/fileutils/version.rb
   24 /builddir/build/BUILD/ruby-2.6.3/.ext/aarch64-linux/etc.so
   25 /builddir/build/BUILD/ruby-2.6.3/lib/fileutils.rb
   26 /builddir/build/BUILD/ruby-2.6.3/lib/tmpdir.rb
   27 /builddir/build/BUILD/ruby-2.6.3/lib/tempfile.rb
   28 /builddir/build/BUILD/ruby-2.6.3/test/lib/iseq_loader_checker.rb
   29 /builddir/build/BUILD/ruby-2.6.3/.ext/aarch64-linux/digest.so
   30 /builddir/build/BUILD/ruby-2.6.3/.ext/common/digest.rb
   31 /builddir/build/BUILD/ruby-2.6.3/.ext/aarch64-linux/digest/md5.so
   32 /builddir/build/BUILD/ruby-2.6.3/.ext/aarch64-linux/digest/rmd160.so
   33 /builddir/build/BUILD/ruby-2.6.3/.ext/aarch64-linux/digest/sha1.so
   34 /builddir/build/BUILD/ruby-2.6.3/.ext/aarch64-linux/digest/sha2.so
   35 /builddir/build/BUILD/ruby-2.6.3/.ext/common/digest/sha2.rb
   36 /builddir/build/BUILD/ruby-2.6.3/.ext/aarch64-linux/digest/bubblebabble.so
   37 /builddir/build/BUILD/ruby-2.6.3/test/digest/test_digest.rb
   38 /builddir/build/BUILD/ruby-2.6.3/test/lib/with_different_ofs.rb
   39 /builddir/build/BUILD/ruby-2.6.3/test/digest/test_digest_extend.rb
   40 /builddir/build/BUILD/ruby-2.6.3/.ext/common/psych/versions.rb
   41 /builddir/build/BUILD/ruby-2.6.3/.ext/common/psych/exception.rb
   42 /builddir/build/BUILD/ruby-2.6.3/.ext/common/psych/syntax_error.rb
   43 /builddir/build/BUILD/ruby-2.6.3/.ext/aarch64-linux/psych.so
   44 /builddir/build/BUILD/ruby-2.6.3/.ext/aarch64-linux/stringio.so
   45 /builddir/build/BUILD/ruby-2.6.3/.ext/common/psych/omap.rb
   46 /builddir/build/BUILD/ruby-2.6.3/.ext/common/psych/set.rb
   47 /builddir/build/BUILD/ruby-2.6.3/.ext/common/psych/class_loader.rb
   48 /builddir/build/BUILD/ruby-2.6.3/.ext/aarch64-linux/strscan.so
   49 /builddir/build/BUILD/ruby-2.6.3/.ext/common/psych/scalar_scanner.rb
   50 /builddir/build/BUILD/ruby-2.6.3/.ext/common/psych/nodes/node.rb
   51 /builddir/build/BUILD/ruby-2.6.3/.ext/common/psych/nodes/stream.rb
   52 /builddir/build/BUILD/ruby-2.6.3/.ext/common/psych/nodes/document.rb
   53 /builddir/build/BUILD/ruby-2.6.3/.ext/common/psych/nodes/sequence.rb
   54 /builddir/build/BUILD/ruby-2.6.3/.ext/common/psych/nodes/scalar.rb
   55 /builddir/build/BUILD/ruby-2.6.3/.ext/common/psych/nodes/mapping.rb
   56 /builddir/build/BUILD/ruby-2.6.3/.ext/common/psych/nodes/alias.rb
   57 /builddir/build/BUILD/ruby-2.6.3/.ext/common/psych/nodes.rb
   58 /builddir/build/BUILD/ruby-2.6.3/.ext/common/psych/streaming.rb
   59 /builddir/build/BUILD/ruby-2.6.3/.ext/common/psych/visitors/visitor.rb
   60 /builddir/build/BUILD/ruby-2.6.3/.ext/common/psych/visitors/to_ruby.rb
   61 /builddir/build/BUILD/ruby-2.6.3/.ext/common/psych/visitors/emitter.rb
   62 /builddir/build/BUILD/ruby-2.6.3/.ext/common/psych/handler.rb
   63 /builddir/build/BUILD/ruby-2.6.3/.ext/common/psych/tree_builder.rb
   64 /builddir/build/BUILD/ruby-2.6.3/.ext/common/psych/visitors/yaml_tree.rb
   65 /builddir/build/BUILD/ruby-2.6.3/.ext/common/psych/json/ruby_events.rb
   66 /builddir/build/BUILD/ruby-2.6.3/.ext/common/psych/visitors/json_tree.rb
   67 /builddir/build/BUILD/ruby-2.6.3/.ext/common/psych/visitors/depth_first.rb
   68 /builddir/build/BUILD/ruby-2.6.3/.ext/common/psych/visitors.rb
   69 /builddir/build/BUILD/ruby-2.6.3/.ext/common/psych/parser.rb
   70 /builddir/build/BUILD/ruby-2.6.3/.ext/common/psych/coder.rb
   71 /builddir/build/BUILD/ruby-2.6.3/.ext/common/psych/core_ext.rb
   72 /builddir/build/BUILD/ruby-2.6.3/.ext/common/psych/stream.rb
   73 /builddir/build/BUILD/ruby-2.6.3/.ext/common/psych/json/yaml_events.rb
   74 /builddir/build/BUILD/ruby-2.6.3/.ext/common/psych/json/tree_builder.rb
   75 /builddir/build/BUILD/ruby-2.6.3/.ext/common/psych/json/stream.rb
   76 /builddir/build/BUILD/ruby-2.6.3/.ext/common/psych/handlers/document_stream.rb
   77 /builddir/build/BUILD/ruby-2.6.3/.ext/common/psych.rb
   78 /builddir/build/BUILD/ruby-2.6.3/lib/yaml.rb
   79 /builddir/build/BUILD/ruby-2.6.3/lib/pstore.rb
   80 /builddir/build/BUILD/ruby-2.6.3/lib/yaml/store.rb
   81 /builddir/build/BUILD/ruby-2.6.3/test/yaml/test_store.rb
   82 /builddir/build/BUILD/ruby-2.6.3/test/test_pstore.rb
   83 /builddir/build/BUILD/ruby-2.6.3/.ext/aarch64-linux/zlib.so
   84 /builddir/build/BUILD/ruby-2.6.3/test/zlib/test_zlib.rb
   85 /builddir/build/BUILD/ruby-2.6.3/.ext/aarch64-linux/fiddle.so
   86 /builddir/build/BUILD/ruby-2.6.3/.ext/common/fiddle/function.rb
   87 /builddir/build/BUILD/ruby-2.6.3/.ext/common/fiddle/closure.rb
   88 /builddir/build/BUILD/ruby-2.6.3/.ext/common/fiddle.rb
   89 /builddir/build/BUILD/ruby-2.6.3/test/fiddle/helper.rb
   90 /builddir/build/BUILD/ruby-2.6.3/test/fiddle/test_closure.rb
   91 /builddir/build/BUILD/ruby-2.6.3/.ext/common/fiddle/value.rb
   92 /builddir/build/BUILD/ruby-2.6.3/.ext/common/fiddle/pack.rb
   93 /builddir/build/BUILD/ruby-2.6.3/.ext/common/fiddle/struct.rb
   94 /builddir/build/BUILD/ruby-2.6.3/test/fiddle/test_c_union_entity.rb
   95 /builddir/build/BUILD/ruby-2.6.3/.ext/common/fiddle/cparser.rb
   96 /builddir/build/BUILD/ruby-2.6.3/.ext/common/fiddle/import.rb
* Process memory map:
aaaaaaaa0000-aaaaaaab0000 r-xp 00000000 08:05 133460                     /builddir/build/BUILD/ruby-2.6.3/ruby
aaaaaaab0000-aaaaaaac0000 r--p 00000000 08:05 133460                     /builddir/build/BUILD/ruby-2.6.3/ruby
aaaaaaac0000-aaaaaaad0000 rw-p 00010000 08:05 133460                     /builddir/build/BUILD/ruby-2.6.3/ruby
aaaaaaad0000-aaaaab0e0000 rw-p 00000000 00:00 0                          [heap]
ffffba7b0000-ffffbb840000 r--s 00000000 08:05 133443                     /builddir/build/BUILD/ruby-2.6.3/libruby.so.2.6.3
ffffbb840000-ffffbb860000 r--s 00000000 08:05 133460                     /builddir/build/BUILD/ruby-2.6.3/ruby
ffffbb860000-ffffbb880000 r-xp 00000000 08:05 5636615                    /usr/lib64/libgcc_s-8-20190507.so.1
ffffbb880000-ffffbb890000 r--p 00010000 08:05 5636615                    /usr/lib64/libgcc_s-8-20190507.so.1
ffffbb890000-ffffbb8a0000 rw-p 00020000 08:05 5636615                    /usr/lib64/libgcc_s-8-20190507.so.1
ffffbb8b0000-ffffbb8c0000 r-xp 00000000 08:05 5639808                    /usr/lib64/libffi.so.6.0.2
ffffbb8c0000-ffffbb8d0000 r--p 00000000 08:05 5639808                    /usr/lib64/libffi.so.6.0.2
ffffbb8d0000-ffffbb8e0000 rw-p 00010000 08:05 5639808                    /usr/lib64/libffi.so.6.0.2
ffffbb8e0000-ffffbb8f0000 r-xp 00000000 08:05 791427                     /builddir/build/BUILD/ruby-2.6.3/.ext/aarch64-linux/fiddle.so
ffffbb8f0000-ffffbb900000 r--p 00000000 08:05 791427                     /builddir/build/BUILD/ruby-2.6.3/.ext/aarch64-linux/fiddle.so
ffffbb900000-ffffbb910000 rw-p 00000000 00:00 0 
ffffbb910000-ffffbb920000 r-xp 00000000 08:05 791464                     /builddir/build/BUILD/ruby-2.6.3/.ext/aarch64-linux/zlib.so
ffffbb920000-ffffbb930000 r--p 00000000 08:05 791464                     /builddir/build/BUILD/ruby-2.6.3/.ext/aarch64-linux/zlib.so
ffffbb930000-ffffbb940000 rw-p 00000000 00:00 0 
ffffbb940000-ffffbb950000 r-xp 00000000 08:05 791657                     /builddir/build/BUILD/ruby-2.6.3/.ext/aarch64-linux/strscan.so
ffffbb950000-ffffbb960000 r--p 00000000 08:05 791657                     /builddir/build/BUILD/ruby-2.6.3/.ext/aarch64-linux/strscan.so
ffffbb960000-ffffbb970000 rw-p 00000000 00:00 0 
ffffbb970000-ffffbb980000 r-xp 00000000 08:05 791669                     /builddir/build/BUILD/ruby-2.6.3/.ext/aarch64-linux/stringio.so
ffffbb980000-ffffbb990000 r--p 00000000 08:05 791669                     /builddir/build/BUILD/ruby-2.6.3/.ext/aarch64-linux/stringio.so
ffffbb990000-ffffbb9a0000 rw-p 00000000 00:00 0 
ffffbb9a0000-ffffbb9c0000 r-xp 00000000 08:05 5644502                    /usr/lib64/libyaml-0.so.2.0.5
ffffbb9c0000-ffffbb9d0000 r--p 00010000 08:05 5644502                    /usr/lib64/libyaml-0.so.2.0.5
ffffbb9d0000-ffffbb9e0000 rw-p 00020000 08:05 5644502                    /usr/lib64/libyaml-0.so.2.0.5
ffffbb9e0000-ffffbb9f0000 r-xp 00000000 08:05 791739                     /builddir/build/BUILD/ruby-2.6.3/.ext/aarch64-linux/psych.so
ffffbb9f0000-ffffbba00000 r--p 00000000 08:05 791739                     /builddir/build/BUILD/ruby-2.6.3/.ext/aarch64-linux/psych.so
ffffbba00000-ffffbba10000 rw-p 00000000 00:00 0 
ffffbba10000-ffffbba20000 r-xp 00000000 08:05 791731                     /builddir/build/BUILD/ruby-2.6.3/.ext/aarch64-linux/digest/bubblebabble.so
ffffbba20000-ffffbba30000 r--p 00000000 08:05 791731                     /builddir/build/BUILD/ruby-2.6.3/.ext/aarch64-linux/digest/bubblebabble.so
ffffbba30000-ffffbba40000 rw-p 00000000 00:00 0 
ffffbba40000-ffffbba50000 r-xp 00000000 08:05 791750                     /builddir/build/BUILD/ruby-2.6.3/.ext/aarch64-linux/digest/sha2.so
ffffbba50000-ffffbba60000 r--p 00000000 08:05 791750                     /builddir/build/BUILD/ruby-2.6.3/.ext/aarch64-linux/digest/sha2.so
ffffbba60000-ffffbba70000 rw-p 00000000 00:00 0 
ffffbba70000-ffffbba80000 r-xp 00000000 08:05 791747                     /builddir/build/BUILD/ruby-2.6.3/.ext/aarch64-linux/digest/sha1.so
ffffbba80000-ffffbba90000 r--p 00000000 08:05 791747                     /builddir/build/BUILD/ruby-2.6.3/.ext/aarch64-linux/digest/sha1.so
ffffbba90000-ffffbbaa0000 rw-p 00000000 00:00 0 
ffffbbaa0000-ffffbbab0000 r-xp 00000000 08:05 791746                     /builddir/build/BUILD/ruby-2.6.3/.ext/aarch64-linux/digest/rmd160.so
ffffbbab0000-ffffbbac0000 r--p 00000000 08:05 791746                     /builddir/build/BUILD/ruby-2.6.3/.ext/aarch64-linux/digest/rmd160.so
ffffbbac0000-ffffbbad0000 rw-p 00000000 00:00 0 
ffffbbad0000-ffffbbaf0000 r-xp 00000000 08:05 5639757                    /usr/lib64/libz.so.1.2.11
ffffbbaf0000-ffffbbb00000 r--p 00010000 08:05 5639757                    /usr/lib64/libz.so.1.2.11
ffffbbb00000-ffffbbb10000 rw-p 00000000 00:00 0 
ffffbbb10000-ffffbbd80000 r-xp 00000000 08:05 5640526                    /usr/lib64/libcrypto.so.1.1.1c
ffffbbd80000-ffffbbdb0000 r--p 00260000 08:05 5640526                    /usr/lib64/libcrypto.so.1.1.1c
ffffbbdb0000-ffffbbdc0000 rw-p 00290000 08:05 5640526                    /usr/lib64/libcrypto.so.1.1.1c
ffffbbdc0000-ffffbbe40000 r-xp 00000000 08:05 5640528                    /usr/lib64/libssl.so.1.1.1c
ffffbbe40000-ffffbbe50000 ---p 00080000 08:05 5640528                    /usr/lib64/libssl.so.1.1.1c
ffffbbe50000-ffffbbe60000 r--p 00080000 08:05 5640528                    /usr/lib64/libssl.so.1.1.1c
ffffbbe60000-ffffbbe70000 rw-p 00090000 08:05 5640528                    /usr/lib64/libssl.so.1.1.1c
ffffbbe70000-ffffbbe80000 r-xp 00000000 08:05 791717                     /builddir/build/BUILD/ruby-2.6.3/.ext/aarch64-linux/digest/md5.so
ffffbbe80000-ffffbbe90000 r--p 00000000 08:05 791717                     /builddir/build/BUILD/ruby-2.6.3/.ext/aarch64-linux/digest/md5.so
ffffbbe90000-ffffbbea0000 rw-p 00000000 00:00 0 
ffffbbea0000-ffffbbeb0000 r-xp 00000000 08:05 791030                     /builddir/build/BUILD/ruby-2.6.3/.ext/aarch64-linux/digest.so
ffffbbeb0000-ffffbbec0000 r--p 00000000 08:05 791030                     /builddir/build/BUILD/ruby-2.6.3/.ext/aarch64-linux/digest.so
ffffbbec0000-ffffbbed0000 rw-p 00000000 00:00 0 
ffffbbed0000-ffffbbee0000 r-xp 00000000 08:05 791621                     /builddir/build/BUILD/ruby-2.6.3/.ext/aarch64-linux/etc.so
ffffbbee0000-ffffbbef0000 r--p 00000000 08:05 791621                     /builddir/build/BUILD/ruby-2.6.3/.ext/aarch64-linux/etc.so
ffffbbef0000-ffffbbf00000 rw-p 00000000 00:00 0 
ffffbbf00000-ffffbbf10000 r-xp 00000000 08:05 791741                     /builddir/build/BUILD/ruby-2.6.3/.ext/aarch64-linux/rbconfig/sizeof.so
ffffbbf10000-ffffbbf20000 r--p 00000000 08:05 791741                     /builddir/build/BUILD/ruby-2.6.3/.ext/aarch64-linux/rbconfig/sizeof.so
ffffbbf20000-ffffbbf30000 rw-p 00000000 00:00 0 
ffffbbf30000-ffffbbf40000 r-xp 00000000 08:05 790805                     /builddir/build/BUILD/ruby-2.6.3/.ext/aarch64-linux/enc/trans/transdb.so
ffffbbf40000-ffffbbf50000 r--p 00000000 08:05 790805                     /builddir/build/BUILD/ruby-2.6.3/.ext/aarch64-linux/enc/trans/transdb.so
ffffbbf50000-ffffbbf60000 rw-p 00000000 00:00 0 
ffffbbf60000-ffffbbf70000 r-xp 00000000 08:05 790740                     /builddir/build/BUILD/ruby-2.6.3/.ext/aarch64-linux/enc/encdb.so
ffffbbf70000-ffffbbf80000 r--p 00000000 08:05 790740                     /builddir/build/BUILD/ruby-2.6.3/.ext/aarch64-linux/enc/encdb.so
ffffbbf80000-ffffbe0b0000 rw-p 00000000 00:00 0 
ffffbe0b0000-ffffbe210000 r-xp 00000000 08:05 5639381                    /usr/lib64/libc-2.28.so
ffffbe210000-ffffbe220000 r--p 00150000 08:05 5639381                    /usr/lib64/libc-2.28.so
ffffbe220000-ffffbe230000 rw-p 00160000 08:05 5639381                    /usr/lib64/libc-2.28.so
ffffbe230000-ffffbe2e0000 r-xp 00000000 08:05 5639385                    /usr/lib64/libm-2.28.so
ffffbe2e0000-ffffbe2f0000 r--p 000a0000 08:05 5639385                    /usr/lib64/libm-2.28.so
ffffbe2f0000-ffffbe300000 rw-p 000b0000 08:05 5639385                    /usr/lib64/libm-2.28.so
ffffbe300000-ffffbe320000 r-xp 00000000 08:05 5639780                    /usr/lib64/libcrypt.so.1.1.0
ffffbe320000-ffffbe330000 r--p 00010000 08:05 5639780                    /usr/lib64/libcrypt.so.1.1.0
ffffbe330000-ffffbe340000 rw-p 00000000 00:00 0 
ffffbe340000-ffffbe350000 r-xp 00000000 08:05 5639383                    /usr/lib64/libdl-2.28.so
ffffbe350000-ffffbe360000 r--p 00000000 08:05 5639383                    /usr/lib64/libdl-2.28.so
ffffbe360000-ffffbe370000 rw-p 00010000 08:05 5639383                    /usr/lib64/libdl-2.28.so
ffffbe370000-ffffbe3e0000 r-xp 00000000 08:05 5639770                    /usr/lib64/libgmp.so.10.3.2
ffffbe3e0000-ffffbe3f0000 ---p 00070000 08:05 5639770                    /usr/lib64/libgmp.so.10.3.2
ffffbe3f0000-ffffbe400000 r--p 00070000 08:05 5639770                    /usr/lib64/libgmp.so.10.3.2
ffffbe400000-ffffbe410000 rw-p 00080000 08:05 5639770                    /usr/lib64/libgmp.so.10.3.2
ffffbe410000-ffffbe420000 r-xp 00000000 08:05 5639397                    /usr/lib64/librt-2.28.so
ffffbe420000-ffffbe430000 r--p 00000000 08:05 5639397                    /usr/lib64/librt-2.28.so
ffffbe430000-ffffbe440000 rw-p 00010000 08:05 5639397                    /usr/lib64/librt-2.28.so
ffffbe440000-ffffbe460000 r-xp 00000000 08:05 5639393                    /usr/lib64/libpthread-2.28.so
ffffbe460000-ffffbe470000 r--p 00010000 08:05 5639393                    /usr/lib64/libpthread-2.28.so
ffffbe470000-ffffbe480000 rw-p 00020000 08:05 5639393                    /usr/lib64/libpthread-2.28.so
ffffbe480000-ffffbe490000 rw-p 00000000 00:00 0 
ffffbe490000-ffffbe770000 r-xp 00000000 08:05 133443                     /builddir/build/BUILD/ruby-2.6.3/libruby.so.2.6.3
ffffbe770000-ffffbe780000 ---p 002e0000 08:05 133443                     /builddir/build/BUILD/ruby-2.6.3/libruby.so.2.6.3
ffffbe780000-ffffbe790000 r--p 002e0000 08:05 133443                     /builddir/build/BUILD/ruby-2.6.3/libruby.so.2.6.3
ffffbe790000-ffffbe7a0000 rw-p 002f0000 08:05 133443                     /builddir/build/BUILD/ruby-2.6.3/libruby.so.2.6.3
ffffbe7a0000-ffffbe7b0000 rw-p 00000000 00:00 0 
ffffbe7b0000-ffffbe7c0000 r--p 00000000 00:00 0                          [vvar]
ffffbe7c0000-ffffbe7d0000 r-xp 00000000 00:00 0                          [vdso]
ffffbe7d0000-ffffbe7f0000 r-xp 00000000 08:05 5639374                    /usr/lib64/ld-2.28.so
ffffbe7f0000-ffffbe800000 r--p 00010000 08:05 5639374                    /usr/lib64/ld-2.28.so
ffffbe800000-ffffbe810000 rw-p 00020000 08:05 5639374                    /usr/lib64/ld-2.28.so
ffffff800000-1000000000000 rw-p 00000000 00:00 0                         [stack]
[NOTE]
You may have encountered a bug in the Ruby interpreter or extension libraries.
Bug reports are welcome.
For details: https://www.ruby-lang.org/bugreport.html
make: *** [uncommon.mk:768: yes-test-almost] Aborted
~~~

The simplest reproducer is:

~~~
$ ruby -r 'fiddle.so' -e 'Fiddle::Closure.new(1, [1, 1], 1)'
~~~

As far as I can tell, there were similar issues already, such as [[1], [2]]. We were considering to modify the build options to include `-DUSE_FFI_CLOSURE_ALLOC=1`, but now I think this should be changed upstream by defauld for the following reasons:

1. It is not clear why ```ffi_closure_free``` should not be used on the first place. It seems that the conditional there is just heritage, where older versions of libffi have not supported the ```ffi_closure_free``` function everywhere.
2. The use of ```ffi_closure_free``` should provide better SELinux compatibility [[3]]
3. The macro is unreadable and it is not clear under what conditions is the ```ffi_closure_free``` used.

The PR changes to use the ```ffi_closure_free``` every time except for the old libffi. Should there be some exceptions, it should be properly understood and documented.

[1]: https://bugs.ruby-lang.org/issues/3371
[2]: http://blade.nagaokaut.ac.jp/cgi-bin/vframe.rb/ruby/ruby-dev/41270?40902-41501+split-mode-vertical
[3]: https://bugzilla.redhat.com/show_bug.cgi?id=1727832