### PR TITLE
Remove taint support

### DIFF
--- a/ext/fiddle/function.c
+++ b/ext/fiddle/function.c
@@ -184,15 +184,6 @@ function_call(int argc, VALUE argv[], VALUE self)
 
     TypedData_Get_Struct(self, ffi_cif, &function_data_type, args.cif);
 
-    if (rb_safe_level() >= 1) {
-	for (i = 0; i < argc; i++) {
-	    VALUE src = argv[i];
-	    if (OBJ_TAINTED(src)) {
-		rb_raise(rb_eSecurityError, "tainted parameter not allowed");
-	    }
-	}
-    }
-
     generic_args = ALLOCV(alloc_buffer,
 	(size_t)(argc + 1) * sizeof(void *) + (size_t)argc * sizeof(fiddle_generic));
     args.values = (void **)((char *)generic_args +

--- a/ext/fiddle/handle.c
+++ b/ext/fiddle/handle.c
@@ -1,8 +1,6 @@
 #include <ruby.h>
 #include <fiddle.h>
 
-#define SafeStringValueCStr(v) (rb_check_safe_obj(rb_string_value(&v)), StringValueCStr(v))
-
 VALUE rb_cHandle;
 
 struct dl_handle {
@@ -145,11 +143,11 @@ rb_fiddle_handle_initialize(int argc, VALUE argv[], VALUE self)
 	cflag = RTLD_LAZY | RTLD_GLOBAL;
 	break;
       case 1:
-	clib = NIL_P(lib) ? NULL : SafeStringValueCStr(lib);
+	clib = NIL_P(lib) ? NULL : StringValueCStr(lib);
 	cflag = RTLD_LAZY | RTLD_GLOBAL;
 	break;
       case 2:
-	clib = NIL_P(lib) ? NULL : SafeStringValueCStr(lib);
+	clib = NIL_P(lib) ? NULL : StringValueCStr(lib);
 	cflag = NUM2INT(flag);
 	break;
       default:
@@ -319,7 +317,7 @@ fiddle_handle_sym(void *handle, VALUE symbol)
 # define CHECK_DLERROR
 #endif
     void (*func)();
-    const char *name = SafeStringValueCStr(symbol);
+    const char *name = StringValueCStr(symbol);
 
 #ifdef HAVE_DLERROR
     dlerror();

--- a/ext/fiddle/pointer.c
+++ b/ext/fiddle/pointer.c
@@ -90,7 +90,6 @@ rb_fiddle_ptr_new2(VALUE klass, void *ptr, long size, freefunc_t func)
     data->ptr = ptr;
     data->free = func;
     data->size = size;
-    OBJ_TAINT(val);
 
     return val;
 }
@@ -376,11 +375,11 @@ rb_fiddle_ptr_to_s(int argc, VALUE argv[], VALUE self)
     TypedData_Get_Struct(self, struct ptr_data, &fiddle_ptr_data_type, data);
     switch (rb_scan_args(argc, argv, "01", &arg1)) {
       case 0:
-	val = rb_tainted_str_new2((char*)(data->ptr));
+	val = rb_str_new2((char*)(data->ptr));
 	break;
       case 1:
 	len = NUM2INT(arg1);
-	val = rb_tainted_str_new((char*)(data->ptr), len);
+	val = rb_str_new((char*)(data->ptr), len);
 	break;
       default:
 	rb_bug("rb_fiddle_ptr_to_s");
@@ -414,11 +413,11 @@ rb_fiddle_ptr_to_str(int argc, VALUE argv[], VALUE self)
     TypedData_Get_Struct(self, struct ptr_data, &fiddle_ptr_data_type, data);
     switch (rb_scan_args(argc, argv, "01", &arg1)) {
       case 0:
-	val = rb_tainted_str_new((char*)(data->ptr),data->size);
+	val = rb_str_new((char*)(data->ptr),data->size);
 	break;
       case 1:
 	len = NUM2INT(arg1);
-	val = rb_tainted_str_new((char*)(data->ptr), len);
+	val = rb_str_new((char*)(data->ptr), len);
 	break;
       default:
 	rb_bug("rb_fiddle_ptr_to_str");
@@ -551,7 +550,7 @@ rb_fiddle_ptr_aref(int argc, VALUE argv[], VALUE self)
       case 2:
 	offset = NUM2ULONG(arg0);
 	len    = NUM2ULONG(arg1);
-	retval = rb_tainted_str_new((char *)data->ptr + offset, len);
+	retval = rb_str_new((char *)data->ptr + offset, len);
 	break;
       default:
 	rb_bug("rb_fiddle_ptr_aref()");
@@ -669,7 +668,6 @@ rb_fiddle_ptr_s_to_ptr(VALUE self, VALUE val)
 	if (num == val) wrap = 0;
 	ptr = rb_fiddle_ptr_new(NUM2PTR(num), 0, NULL);
     }
-    OBJ_INFECT(ptr, val);
     if (wrap) RPTR_DATA(ptr)->wrap[0] = wrap;
     return ptr;
 }

--- a/test/fiddle/test_func.rb
+++ b/test/fiddle/test_func.rb
@@ -11,18 +11,6 @@ module Fiddle
       assert_nil f.call(10)
     end
 
-    def test_syscall_with_tainted_string
-      f = Function.new(@libc['system'], [TYPE_VOIDP], TYPE_INT)
-      Thread.new {
-        $SAFE = 1
-        assert_raise(SecurityError) do
-          f.call("uname -rs".dup.taint)
-        end
-      }.join
-    ensure
-      $SAFE = 0
-    end
-
     def test_sinf
       begin
         f = Function.new(@libm['sinf'], [TYPE_FLOAT], TYPE_FLOAT)

--- a/test/fiddle/test_function.rb
+++ b/test/fiddle/test_function.rb
@@ -98,7 +98,7 @@ module Fiddle
     end
 
     def test_no_memory_leak
-      prep = 'r = Fiddle::Function.new(Fiddle.dlopen(nil)["rb_obj_tainted"], [Fiddle::TYPE_UINTPTR_T], Fiddle::TYPE_UINTPTR_T); a = "a"'
+      prep = 'r = Fiddle::Function.new(Fiddle.dlopen(nil)["rb_obj_frozen"], [Fiddle::TYPE_UINTPTR_T], Fiddle::TYPE_UINTPTR_T); a = "a"'
       code = 'begin r.call(a); rescue TypeError; end'
       assert_no_memory_leak(%w[-W0 -rfiddle], "#{prep}\n1000.times{#{code}}", "10_000.times {#{code}}", limit: 1.2)
     end

--- a/test/fiddle/test_handle.rb
+++ b/test/fiddle/test_handle.rb
@@ -8,29 +8,6 @@ module Fiddle
   class TestHandle < TestCase
     include Fiddle
 
-    def test_safe_handle_open
-      Thread.new do
-        $SAFE = 1
-        assert_raise(SecurityError) {
-          Fiddle::Handle.new(LIBC_SO.dup.taint)
-        }
-      end.join
-    ensure
-      $SAFE = 0
-    end
-
-    def test_safe_function_lookup
-      Thread.new do
-        h = Fiddle::Handle.new(LIBC_SO)
-        $SAFE = 1
-        assert_raise(SecurityError) {
-          h["qsort".dup.taint]
-        }
-      end.join
-    ensure
-      $SAFE = 0
-    end
-
     def test_to_i
       handle = Fiddle::Handle.new(LIBC_SO)
       assert_kind_of Integer, handle.to_i

--- a/test/fiddle/test_pointer.rb
+++ b/test/fiddle/test_pointer.rb
@@ -79,7 +79,6 @@ module Fiddle
     def test_to_ptr_string
       str = "hello world"
       ptr = Pointer[str]
-      assert ptr.tainted?, 'pointer should be tainted'
       assert_equal str.length, ptr.size
       assert_equal 'hello', ptr[0,5]
     end


### PR DESCRIPTION
Ruby 2.7 deprecates taint and it no longer has an effect.
The lack of taint support should not cause a problem in
previous Ruby versions.