### PR TITLE
Add Fiddle.ruby_debug_breakpoint

### DIFF
--- a/lib/fiddle/breakpoint.rb
+++ b/lib/fiddle/breakpoint.rb
@@ -1,0 +1,10 @@
+require "fiddle"
+
+module Fiddle
+  @ruby_debug_breakpoint = Function.new(Handle.sym("ruby_debug_breakpoint"),
+                                        [], Fiddle::TYPE_VOID)
+
+  def self.ruby_debug_breakpoint
+    @ruby_debug_breakpoint.()
+  end
+end


### PR DESCRIPTION
libruby.so has `ruby_debug_breakpoint` function that can be used for inserting a breakpoint when debugging on C-layer.
I sometimes need to call this function from Ruby-layer to enter the gdb interactive session.
So I'd like to add `Fiddle.ruby_debug_breakpoint`.