### PR TITLE
Initialize memory to 0 when calling Fiddle.malloc().

### DIFF
--- a/ext/fiddle/fiddle.c
+++ b/ext/fiddle/fiddle.c
@@ -47,8 +47,9 @@ static VALUE
 rb_fiddle_malloc(VALUE self, VALUE size)
 {
     void *ptr;
-
-    ptr = (void*)ruby_xmalloc(NUM2SIZET(size));
+    size_t sizet = NUM2SIZET(size);
+    ptr = (void*)ruby_xmalloc(sizet);
+    memset(ptr, 0, sizet);
     return PTR2NUM(ptr);
 }
 


### PR DESCRIPTION
This pull request was split from #14 as requested by @nobu .

When calling `Fiddle.malloc`, the contents of the resulting memory were not initialized to 0 as they were when calling `Fiddle::Pointer.malloc`. This inconsistency led to unexpected and difficult-to-debug behavior.