### PR TITLE
Make array access override compatible with base class

### DIFF
--- a/lib/fiddle/struct.rb
+++ b/lib/fiddle/struct.rb
@@ -149,7 +149,9 @@ module Fiddle
     end
 
     # Fetch struct member +name+
-    def [](name)
+    def [](*args)
+      return super(*args) if args.size > 1
+      name = args[0]
       idx = @members.index(name)
       if( idx.nil? )
         raise(ArgumentError, "no such member: #{name}")
@@ -183,7 +185,9 @@ module Fiddle
     end
 
     # Set struct member +name+, to value +val+
-    def []=(name, val)
+    def []=(*args)
+      return super(*args) if args.size > 2
+      name, val = *args
       idx = @members.index(name)
       if( idx.nil? )
         raise(ArgumentError, "no such member: #{name}")

--- a/lib/fiddle/struct.rb
+++ b/lib/fiddle/struct.rb
@@ -156,7 +156,7 @@ module Fiddle
     # +offset+.
     #
     # Examples:
-    # 
+    #
     #     my_struct = struct(['int id']).malloc
     #     my_struct.id = 1
     #     my_struct['id'] # => 1
@@ -202,7 +202,7 @@ module Fiddle
     # +offset+ and +length+.
     #
     # Examples:
-    # 
+    #
     #     my_struct = struct(['int id']).malloc
     #     my_struct['id'] = 1
     #     my_struct[0, 4] = "\x01\x00\x00\x00".b

--- a/lib/fiddle/struct.rb
+++ b/lib/fiddle/struct.rb
@@ -54,6 +54,8 @@ module Fiddle
           @entity = klass.entity_class.new(addr, types)
           @entity.assign_names(members)
         }
+        define_method(:[]) { |*args| @entity.send(:[], *args) }
+        define_method(:[]=) { |*args| @entity.send(:[]=, *args) }
         define_method(:to_ptr){ @entity }
         define_method(:to_i){ @entity.to_i }
         members.each{|name|
@@ -148,7 +150,18 @@ module Fiddle
       @size = PackInfo.align(offset, max_align)
     end
 
-    # Fetch struct member +name+
+    # Fetch struct member +name+ if only one argument is specified. If two
+    # arguments are specified, the first is an offset and the second is a
+    # length and this method returns the string of +length+ bytes beginning at
+    # +offset+.
+    #
+    # Examples:
+    # 
+    #     my_struct = struct(['int id']).malloc
+    #     my_struct.id = 1
+    #     my_struct['id'] # => 1
+    #     my_struct[0, 4] # => "\x01\x00\x00\x00".b
+    #
     def [](*args)
       return super(*args) if args.size > 1
       name = args[0]
@@ -184,7 +197,17 @@ module Fiddle
       end
     end
 
-    # Set struct member +name+, to value +val+
+    # Set struct member +name+, to value +val+. If more arguments are
+    # specified, writes the string of bytes to the memory at the given
+    # +offset+ and +length+.
+    #
+    # Examples:
+    # 
+    #     my_struct = struct(['int id']).malloc
+    #     my_struct['id'] = 1
+    #     my_struct[0, 4] = "\x01\x00\x00\x00".b
+    #     my_struct.id # => 1
+    #
     def []=(*args)
       return super(*args) if args.size > 2
       name, val = *args

--- a/test/fiddle/test_import.rb
+++ b/test/fiddle/test_import.rb
@@ -107,6 +107,14 @@ module Fiddle
       assert_equal([0,1,2], ary.value)
     end
 
+    def test_struct_array_subscript_multiarg()
+      struct = Fiddle::Importer.struct([ 'int x' ]).malloc
+      assert_equal("\x00".b * Fiddle::SIZEOF_INT, struct.to_ptr[0, Fiddle::SIZEOF_INT])
+
+      struct.to_ptr[0, Fiddle::SIZEOF_INT] = "\x01".b * Fiddle::SIZEOF_INT
+      assert_equal 16843009, struct.x
+    end
+
     def test_struct()
       s = LIBC::MyStruct.malloc()
       s.num = [0,1,2,3,4]

--- a/test/fiddle/test_import.rb
+++ b/test/fiddle/test_import.rb
@@ -54,6 +54,16 @@ module Fiddle
       assert_match(/call dlload before/, err.message)
     end
 
+    def test_struct_memory_access
+      my_struct = Fiddle::Importer.struct(['int id']).malloc
+      my_struct['id'] = 1
+      my_struct[0, Fiddle::SIZEOF_INT] = "\x01".b * Fiddle::SIZEOF_INT
+      refute_equal 0, my_struct.id
+
+      my_struct.id = 0
+      assert_equal "\x00".b * Fiddle::SIZEOF_INT, my_struct[0, Fiddle::SIZEOF_INT]
+    end
+
     def test_malloc()
       s1 = LIBC::Timeval.malloc()
       s2 = LIBC::Timeval.malloc()


### PR DESCRIPTION
This pull request was split from #14 as requested by @nobu .

`CStructEntity` defines array subscript methods (`[]` / `[]=`), which is fine except that they override `Fiddle::Pointer#[]` and `Fiddle::Pointer#[]=` and do not handle the 3rd argument that the base class allows for. The methods from `Fiddle::Pointer` provide for direct manipulation of the underlying memory, but this ability is lost in `CStructEntity` because the superclass methods are not available in the subclass (ignoring ugly hacks like `Fiddle::Pointer.method(:[]).unbind.bind(struct).call`). This pull request modifies the overridden methods to check for an additional argument which would be understood by `super`. If the extra argument is provided, `super` is called so that the underlying memory can be accessed / assigned directly.

Here is an example:

```ruby
# This could be done before the pull request
ptr = Fiddle::Pointer.malloc(4)
ptr[0, 4] = "\x01\x02\x03\x04".b
ptr[0, 4].unpack("i") #=> [67305985]

# This could be done before the pull request
s = Fiddle::Importer.struct(['int i']).malloc
s.i = 0x04030201
s.i #=> 67305985

# But, this could not be done. Pull request adds support for this behavior.
s = Fiddle::Importer.struct(['int i']).malloc
s[0, 4] = "\x01\x02\x03\x04".b
s.i #=> 67305985
s.i = 0x04030201
s[0, 4] #=> "\x01\x02\x03\x04"
```