### PR TITLE
Fix assignment to array within struct

### DIFF
--- a/lib/fiddle/struct.rb
+++ b/lib/fiddle/struct.rb
@@ -39,7 +39,7 @@ module Fiddle
 
     def []=(index, value)
       if index < 0 || index >= size
-        raise RangeError, 'index %d outside of array bounds 0...%d' % [index, size]
+        raise IndexError, 'index %d outside of array bounds 0...%d' % [index, size]
       end
 
       to_ptr[index * @align, @size] = [value].pack(@pack_format)

--- a/lib/fiddle/struct.rb
+++ b/lib/fiddle/struct.rb
@@ -149,7 +149,9 @@ module Fiddle
     end
 
     # Fetch struct member +name+
-    def [](name)
+    def [](*args)
+      return super(*args) if args.size > 1
+      name = args[0]
       idx = @members.index(name)
       if( idx.nil? )
         raise(ArgumentError, "no such member: #{name}")
@@ -183,7 +185,9 @@ module Fiddle
     end
 
     # Set struct member +name+, to value +val+
-    def []=(name, val)
+    def []=(*args)
+      return super(*args) if args.size > 2
+      name, val = *args
       idx = @members.index(name)
       if( idx.nil? )
         raise(ArgumentError, "no such member: #{name}")

--- a/lib/fiddle/struct.rb
+++ b/lib/fiddle/struct.rb
@@ -20,6 +20,33 @@ module Fiddle
     end
   end
 
+  # Wrapper for arrays within a struct
+  class StructArray < Array
+    include ValueUtil
+
+    def initialize(ptr, type, initial_values)
+      @ptr = ptr
+      @type = type
+      @align = PackInfo::ALIGN_MAP[type]
+      @size = Fiddle::PackInfo::SIZE_MAP[type]
+      @pack_format = Fiddle::PackInfo::PACK_MAP[type]
+      super(initial_values.collect { |v| unsigned_value(v, type) })
+    end
+
+    def to_ptr
+      @ptr
+    end
+
+    def []=(index, value)
+      if index < 0 || index >= size
+        raise RangeError, 'index %d outside of array bounds 0...%d' % [index, size]
+      end
+
+      to_ptr[index * @align, @size] = [value].pack(@pack_format)
+      super(index, value)
+    end
+  end
+
   # Used to construct C classes (CUnion, CStruct, etc)
   #
   # Fiddle::Importer#struct and Fiddle::Importer#union wrap this functionality in an
@@ -191,7 +218,7 @@ module Fiddle
       if( ty.is_a?(Integer) && (ty < 0) )
         return unsigned_value(val, ty)
       elsif( ty.is_a?(Array) && (ty[0] < 0) )
-        return val.collect{|v| unsigned_value(v,ty[0])}
+        return StructArray.new(self + @offset[idx], ty[0], val)
       else
         return val
       end

--- a/lib/fiddle/struct.rb
+++ b/lib/fiddle/struct.rb
@@ -42,7 +42,7 @@ module Fiddle
         raise IndexError, 'index %d outside of array bounds 0...%d' % [index, size]
       end
 
-      to_ptr[index * @align, @size] = [value].pack(@pack_format)
+      to_ptr[index * @size, @size] = [value].pack(@pack_format)
       super(index, value)
     end
   end

--- a/lib/fiddle/struct.rb
+++ b/lib/fiddle/struct.rb
@@ -54,6 +54,8 @@ module Fiddle
           @entity = klass.entity_class.new(addr, types)
           @entity.assign_names(members)
         }
+        define_method(:[]) { |*args| @entity.send(:[], *args) }
+        define_method(:[]=) { |*args| @entity.send(:[]=, *args) }
         define_method(:to_ptr){ @entity }
         define_method(:to_i){ @entity.to_i }
         members.each{|name|
@@ -148,7 +150,18 @@ module Fiddle
       @size = PackInfo.align(offset, max_align)
     end
 
-    # Fetch struct member +name+
+    # Fetch struct member +name+ if only one argument is specified. If two
+    # arguments are specified, the first is an offset and the second is a
+    # length and this method returns the string of +length+ bytes beginning at
+    # +offset+.
+    #
+    # Examples:
+    # 
+    #     my_struct = struct(['int id']).malloc
+    #     my_struct.id = 1
+    #     my_struct['id'] # => 1
+    #     my_struct[0, 4] # => "\x01\x00\x00\x00".b
+    #
     def [](*args)
       return super(*args) if args.size > 1
       name = args[0]
@@ -184,7 +197,17 @@ module Fiddle
       end
     end
 
-    # Set struct member +name+, to value +val+
+    # Set struct member +name+, to value +val+. If more arguments are
+    # specified, writes the string of bytes to the memory at the given
+    # +offset+ and +length+.
+    #
+    # Examples:
+    # 
+    #     my_struct = struct(['int id']).malloc
+    #     my_struct['id'] = 1
+    #     my_struct[0, 4] = "\x01\x00\x00\x00".b
+    #     my_struct.id # => 1
+    #
     def []=(*args)
       return super(*args) if args.size > 2
       name, val = *args

--- a/test/fiddle/test_import.rb
+++ b/test/fiddle/test_import.rb
@@ -135,8 +135,8 @@ module Fiddle
       assert_equal 1024, instance.stages[0]
       assert_equal [1024].pack(Fiddle::PackInfo::PACK_MAP[-Fiddle::TYPE_INT]),
                    instance.to_ptr[0, Fiddle::SIZEOF_INT]
-      assert_raise(RangeError) { instance.stages[-1] = 5 }
-      assert_raise(RangeError) { instance.stages[2] = 5 }
+      assert_raise(IndexError) { instance.stages[-1] = 5 }
+      assert_raise(IndexError) { instance.stages[2] = 5 }
     end
 
     def test_struct()

--- a/test/fiddle/test_import.rb
+++ b/test/fiddle/test_import.rb
@@ -130,13 +130,17 @@ module Fiddle
     end
 
     def test_struct_array_assignment()
-      instance = Fiddle::Importer.struct(["unsigned int stages[1]"]).malloc
+      instance = Fiddle::Importer.struct(["unsigned int stages[3]"]).malloc
       instance.stages[0] = 1024
+      instance.stages[1] = 10
+      instance.stages[2] = 100
       assert_equal 1024, instance.stages[0]
-      assert_equal [1024].pack(Fiddle::PackInfo::PACK_MAP[-Fiddle::TYPE_INT]),
-                   instance.to_ptr[0, Fiddle::SIZEOF_INT]
+      assert_equal 10, instance.stages[1]
+      assert_equal 100, instance.stages[2]
+      assert_equal [1024, 10, 100].pack(Fiddle::PackInfo::PACK_MAP[-Fiddle::TYPE_INT] * 3),
+                   instance.to_ptr[0, 3 * Fiddle::SIZEOF_INT]
       assert_raise(IndexError) { instance.stages[-1] = 5 }
-      assert_raise(IndexError) { instance.stages[2] = 5 }
+      assert_raise(IndexError) { instance.stages[3] = 5 }
     end
 
     def test_struct()

--- a/test/fiddle/test_import.rb
+++ b/test/fiddle/test_import.rb
@@ -107,6 +107,14 @@ module Fiddle
       assert_equal([0,1,2], ary.value)
     end
 
+    def test_struct_array_subscript_multiarg()
+      struct = Fiddle::Importer.struct([ 'int x' ]).malloc
+      assert_equal("\x00".b * Fiddle::SIZEOF_INT, struct.to_ptr[0, Fiddle::SIZEOF_INT])
+
+      struct.to_ptr[0, Fiddle::SIZEOF_INT] = "\x01".b * Fiddle::SIZEOF_INT
+      assert_equal 16843009, struct.x
+    end
+
     def test_struct()
       s = LIBC::MyStruct.malloc()
       s.num = [0,1,2,3,4]

--- a/test/fiddle/test_import.rb
+++ b/test/fiddle/test_import.rb
@@ -129,6 +129,16 @@ module Fiddle
       assert_equal([0,1,2], ary.value)
     end
 
+    def test_struct_array_assignment()
+      instance = Fiddle::Importer.struct(["unsigned int stages[1]"]).malloc
+      instance.stages[0] = 1024
+      assert_equal 1024, instance.stages[0]
+      assert_equal [1024].pack(Fiddle::PackInfo::PACK_MAP[-Fiddle::TYPE_INT]),
+                   instance.to_ptr[0, Fiddle::SIZEOF_INT]
+      assert_raise(RangeError) { instance.stages[-1] = 5 }
+      assert_raise(RangeError) { instance.stages[2] = 5 }
+    end
+
     def test_struct()
       s = LIBC::MyStruct.malloc()
       s.num = [0,1,2,3,4]

--- a/test/fiddle/test_import.rb
+++ b/test/fiddle/test_import.rb
@@ -54,6 +54,16 @@ module Fiddle
       assert_match(/call dlload before/, err.message)
     end
 
+    def test_struct_memory_access
+      my_struct = Fiddle::Importer.struct(['int id']).malloc
+      my_struct['id'] = 1
+      my_struct[0, Fiddle::SIZEOF_INT] = "\x01".b * Fiddle::SIZEOF_INT
+      refute_equal 0, my_struct.id
+
+      my_struct.id = 0
+      assert_equal "\x00".b * Fiddle::SIZEOF_INT, my_struct[0, Fiddle::SIZEOF_INT]
+    end
+
     def test_malloc()
       s1 = LIBC::Timeval.malloc()
       s2 = LIBC::Timeval.malloc()


### PR DESCRIPTION
This pull request was split from #14 as requested by @nobu . It depends on #25 because that pull request makes it possible to access the underlying memory of a struct, which is required in order for this pull request to work properly.

When a member of a struct is an array, `CStructEntity` would return a temporary array containing those values. Assignment to that array was a no-op, which led to confusing behavior because an assignment to the array would be "ignored". I fixed this so that assignment to the returned array correctly updates the member within the struct.

For example:

```ruby
a = struct(['int i[5]']).malloc
a.i[2] = 1 # previously, this would do nothing
a.i[2] #=> 1
```