### PR TITLE
Add GH Actions

### DIFF
--- a/.github/workflows/fiddle.yml
+++ b/.github/workflows/fiddle.yml
@@ -1,0 +1,42 @@
+name: CI
+
+on: [push, pull_request]
+
+jobs:
+  CI:
+    name: >-
+      ${{ matrix.os }} ${{ matrix.ruby }}
+    runs-on: ${{ matrix.os }}-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ ubuntu, macos, windows ]
+        ruby: [ 2.3, 2.4, 2.5, 2.6, 2.7, head ]
+        include:
+          - { os: windows , ruby: mingw }
+          - { os: windows , ruby: mswin }
+        exclude:
+          - { os: windows , ruby: head }
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Set up Ruby
+        uses: MSP-Greg/setup-ruby-pkgs@v1
+        with:
+          ruby-version: ${{ matrix.ruby }}
+          mingw: _upgrade_ libffi
+
+      - name: bundle install
+        run:  bundle install
+
+      - name: rake compile
+        run:  rake compile
+
+      - name: rake install
+        run:  rake install
+
+      - name: rake test
+        run:  |
+          ruby -v
+          rake test


### PR DESCRIPTION
Today the ruby head mswin build broke from fiddle.  ruby/ruby appears to download libffi 3.2.1 for the mswin build, but 3.3 is vendored here.

I started here and created a GitHub Actions workflow, covering Ruby 2.3 thru master/head for Ubuntu, macOS, and Windows.  All are passing except Windows mswin.   I did add a compile step just to see what was happening.

This may not run, as often the first PR with a GHA workflow doesn't.  A link to a run in my fork is:
https://github.com/MSP-Greg/fiddle/actions/runs/116195157