### PR TITLE
Add a Fiddle::Pointer#call_free method

### DIFF
--- a/ext/fiddle/pointer.c
+++ b/ext/fiddle/pointer.c
@@ -232,7 +232,7 @@ rb_fiddle_ptr_initialize(int argc, VALUE argv[], VALUE self)
  * if not already manually called via *call_free*.
  *
  * +freefunc+ must be an address pointing to a function or an instance of
- * +Fiddle::Function+. Using +freefunc+ without using +free!+ may lead to
+ * +Fiddle::Function+. Using +freefunc+ without using +call_free+ may lead to
  * unlimited memory being allocated before any is freed as the native memory
  * the pointer references does not contribute to triggering the Ruby garbage
  * collector. Consider manually freeing the memory as illustrated above. You

--- a/ext/fiddle/pointer.c
+++ b/ext/fiddle/pointer.c
@@ -63,9 +63,9 @@ fiddle_ptr_free_ptr(void *ptr)
 {
     struct ptr_data *data = ptr;
     if (data->ptr && data->free && !data->freed) {
+	data->freed = true;
 	(*(data->free))(data->ptr);
     }
-    data->freed = true;
 }
 
 static void

--- a/ext/fiddle/pointer.c
+++ b/ext/fiddle/pointer.c
@@ -387,13 +387,13 @@ rb_fiddle_ptr_free_get(VALUE self)
 }
 
 /*
- * call-seq: free! => nil
+ * call-seq: call_free => nil
  *
  * Call the free function for this pointer. Calling more than once will do
  * nothing. Does nothing if there is no free function attached.
  */
 static VALUE
-rb_fiddle_ptr_free_bang(VALUE self)
+rb_fiddle_ptr_call_free(VALUE self)
 {
     struct ptr_data *pdata;
     TypedData_Get_Struct(self, struct ptr_data, &fiddle_ptr_data_type, pdata);
@@ -755,7 +755,7 @@ Init_fiddle_pointer(void)
     rb_define_method(rb_cPointer, "initialize", rb_fiddle_ptr_initialize, -1);
     rb_define_method(rb_cPointer, "free=", rb_fiddle_ptr_free_set, 1);
     rb_define_method(rb_cPointer, "free",  rb_fiddle_ptr_free_get, 0);
-    rb_define_method(rb_cPointer, "free!",  rb_fiddle_ptr_free_bang, 0);
+    rb_define_method(rb_cPointer, "call_free",  rb_fiddle_ptr_call_free, 0);
     rb_define_method(rb_cPointer, "freed?",  rb_fiddle_ptr_freed_p, 0);
     rb_define_method(rb_cPointer, "to_i",  rb_fiddle_ptr_to_i, 0);
     rb_define_method(rb_cPointer, "to_int",  rb_fiddle_ptr_to_i, 0);

--- a/ext/fiddle/pointer.c
+++ b/ext/fiddle/pointer.c
@@ -229,7 +229,7 @@ rb_fiddle_ptr_initialize(int argc, VALUE argv[], VALUE self)
  *
  * Allocate +size+ bytes of memory and associate it with an optional
  * +freefunc+ that will be called when the pointer is garbage collected,
- * if not already manually called via *free!*.
+ * if not already manually called via *call_free*.
  *
  * +freefunc+ must be an address pointing to a function or an instance of
  * +Fiddle::Function+. Using +freefunc+ without using +free!+ may lead to

--- a/ext/fiddle/pointer.c
+++ b/ext/fiddle/pointer.c
@@ -209,7 +209,7 @@ rb_fiddle_ptr_initialize(int argc, VALUE argv[], VALUE self)
  *    # Manually freeing but relying on the garbage collector otherwise
  *    pointer = Fiddle::Pointer.malloc(size, Fiddle::RUBY_FREE)
  *    ...
- *    pointer.free!
+ *    pointer.call_free
  *
  *    # Relying on the garbage collector - may lead to unlimited memory allocated before freeing any, but safe
  *    pointer = Fiddle::Pointer.malloc(size, Fiddle::RUBY_FREE)

--- a/ext/fiddle/pointer.c
+++ b/ext/fiddle/pointer.c
@@ -2,6 +2,7 @@
  * $Id$
  */
 
+#include <stdbool.h>
 #include <ruby/ruby.h>
 #include <ruby/io.h>
 #include <ctype.h>
@@ -24,7 +25,7 @@ struct ptr_data {
     void *ptr;
     long size;
     freefunc_t free;
-    int freed;
+    bool freed;
     VALUE wrap[2];
 };
 
@@ -64,7 +65,7 @@ fiddle_ptr_free_ptr(void *ptr)
     if (data->ptr && data->free && !data->freed) {
 	(*(data->free))(data->ptr);
     }
-    data->freed = 1;
+    data->freed = true;
 }
 
 static void
@@ -95,7 +96,7 @@ rb_fiddle_ptr_new2(VALUE klass, void *ptr, long size, freefunc_t func)
     val = TypedData_Make_Struct(klass, struct ptr_data, &fiddle_ptr_data_type, data);
     data->ptr = ptr;
     data->free = func;
-    data->freed = 0;
+    data->freed = false;
     data->size = size;
 
     return val;
@@ -147,7 +148,7 @@ rb_fiddle_ptr_s_allocate(VALUE klass)
     data->ptr = 0;
     data->size = 0;
     data->free = 0;
-    data->freed = 0;
+    data->freed = false;
 
     return obj;
 }

--- a/ext/fiddle/pointer.c
+++ b/ext/fiddle/pointer.c
@@ -390,7 +390,7 @@ rb_fiddle_ptr_free_get(VALUE self)
  * call-seq: free! => nil
  *
  * Call the free function for this pointer. Calling more than once will do
- * nothing.
+ * nothing. Does nothing if there is no free function attached.
  */
 static VALUE
 rb_fiddle_ptr_free_bang(VALUE self)
@@ -404,7 +404,7 @@ rb_fiddle_ptr_free_bang(VALUE self)
 /*
  * call-seq: freed? => bool
  *
- * Returns if this pointer has already been freed.
+ * Returns if the free function for this pointer has been called.
  */
 static VALUE
 rb_fiddle_ptr_freed_p(VALUE self)

--- a/test/fiddle/test_pointer.rb
+++ b/test/fiddle/test_pointer.rb
@@ -24,7 +24,7 @@ module Fiddle
         assert_equal 10, ptr.size
         assert_equal free.to_i, ptr.free.to_i
       ensure
-        ptr.free!
+        ptr.call_free
       end
       assert ptr.freed?
     end
@@ -38,7 +38,7 @@ module Fiddle
         assert_equal 10, ptr.size
         assert_equal free.to_i, ptr.free.to_i
       ensure
-        ptr.free!
+        ptr.call_free
       end
       assert ptr.freed?
     end
@@ -109,7 +109,7 @@ module Fiddle
           assert_equal f.read(9), buf.to_s
         end
       ensure
-        buf.free!
+        buf.call_free
       end
     end
 
@@ -188,9 +188,9 @@ module Fiddle
     def test_free_with_func
       ptr = Pointer.malloc(4, Fiddle::RUBY_FREE)
       refute ptr.freed?
-      ptr.free!
+      ptr.call_free
       assert ptr.freed?
-      ptr.free!                 # you can safely run it again
+      ptr.call_free                 # you can safely run it again
       assert ptr.freed?
       GC.start                  # you can safely run the GC routine
       assert ptr.freed?
@@ -199,16 +199,16 @@ module Fiddle
     def test_free_with_no_func
       ptr = Pointer.malloc(4)
       refute ptr.freed?
-      ptr.free!
+      ptr.call_free
       refute ptr.freed?
-      ptr.free!                 # you can safely run it again
+      ptr.call_free                 # you can safely run it again
       refute ptr.freed?
     end
 
     def test_freed?
       ptr = Pointer.malloc(4, Fiddle::RUBY_FREE)
       refute ptr.freed?
-      ptr.free!
+      ptr.call_free
       assert ptr.freed?
     end
 

--- a/test/fiddle/test_pointer.rb
+++ b/test/fiddle/test_pointer.rb
@@ -20,27 +20,16 @@ module Fiddle
       assert_equal free.to_i, Fiddle::RUBY_FREE.to_i
 
       ptr  = Pointer.malloc(10, free.to_i)
-      begin
-        assert_equal 10, ptr.size
-        assert_equal free.to_i, ptr.free.to_i
-      ensure
-        ptr.call_free
-      end
-      assert ptr.freed?
+      assert_equal 10, ptr.size
+      assert_equal free.to_i, ptr.free.to_i
     end
 
     def test_malloc_free_func
       free = Fiddle::Function.new(Fiddle::RUBY_FREE, [TYPE_VOIDP], TYPE_VOID)
 
       ptr  = Pointer.malloc(10, free)
-      refute ptr.freed?
-      begin
-        assert_equal 10, ptr.size
-        assert_equal free.to_i, ptr.free.to_i
-      ensure
-        ptr.call_free
-      end
-      assert ptr.freed?
+      assert_equal 10, ptr.size
+      assert_equal free.to_i, ptr.free.to_i
     end
 
     def test_to_str
@@ -96,20 +85,16 @@ module Fiddle
 
     def test_to_ptr_io
       buf = Pointer.malloc(10, Fiddle::RUBY_FREE)
-      begin
-        File.open(__FILE__, 'r') do |f|
-          ptr = Pointer.to_ptr f
-          fread = Function.new(@libc['fread'],
-                              [TYPE_VOIDP, TYPE_INT, TYPE_INT, TYPE_VOIDP],
-                              TYPE_INT)
-          fread.call(buf.to_i, Fiddle::SIZEOF_CHAR, buf.size - 1, ptr.to_i)
-        end
+      File.open(__FILE__, 'r') do |f|
+        ptr = Pointer.to_ptr f
+        fread = Function.new(@libc['fread'],
+                             [TYPE_VOIDP, TYPE_INT, TYPE_INT, TYPE_VOIDP],
+                             TYPE_INT)
+        fread.call(buf.to_i, Fiddle::SIZEOF_CHAR, buf.size - 1, ptr.to_i)
+      end
 
-        File.open(__FILE__, 'r') do |f|
-          assert_equal f.read(9), buf.to_s
-        end
-      ensure
-        buf.call_free
+      File.open(__FILE__, 'r') do |f|
+        assert_equal f.read(9), buf.to_s
       end
     end
 

--- a/test/fiddle/test_pointer.rb
+++ b/test/fiddle/test_pointer.rb
@@ -20,16 +20,28 @@ module Fiddle
       assert_equal free.to_i, Fiddle::RUBY_FREE.to_i
 
       ptr  = Pointer.malloc(10, free.to_i)
-      assert_equal 10, ptr.size
-      assert_equal free.to_i, ptr.free.to_i
+      refute ptr.freed?
+      begin
+        assert_equal 10, ptr.size
+        assert_equal free.to_i, ptr.free.to_i
+      ensure
+        ptr.free!
+      end
+      assert ptr.freed?
     end
 
     def test_malloc_free_func
       free = Fiddle::Function.new(Fiddle::RUBY_FREE, [TYPE_VOIDP], TYPE_VOID)
 
       ptr  = Pointer.malloc(10, free)
-      assert_equal 10, ptr.size
-      assert_equal free.to_i, ptr.free.to_i
+      refute ptr.freed?
+      begin
+        assert_equal 10, ptr.size
+        assert_equal free.to_i, ptr.free.to_i
+      ensure
+        ptr.free!
+      end
+      assert ptr.freed?
     end
 
     def test_to_str
@@ -85,16 +97,20 @@ module Fiddle
 
     def test_to_ptr_io
       buf = Pointer.malloc(10, Fiddle::RUBY_FREE)
-      File.open(__FILE__, 'r') do |f|
-        ptr = Pointer.to_ptr f
-        fread = Function.new(@libc['fread'],
-                             [TYPE_VOIDP, TYPE_INT, TYPE_INT, TYPE_VOIDP],
-                             TYPE_INT)
-        fread.call(buf.to_i, Fiddle::SIZEOF_CHAR, buf.size - 1, ptr.to_i)
-      end
+      begin
+        File.open(__FILE__, 'r') do |f|
+          ptr = Pointer.to_ptr f
+          fread = Function.new(@libc['fread'],
+                              [TYPE_VOIDP, TYPE_INT, TYPE_INT, TYPE_VOIDP],
+                              TYPE_INT)
+          fread.call(buf.to_i, Fiddle::SIZEOF_CHAR, buf.size - 1, ptr.to_i)
+        end
 
-      File.open(__FILE__, 'r') do |f|
-        assert_equal f.read(9), buf.to_s
+        File.open(__FILE__, 'r') do |f|
+          assert_equal f.read(9), buf.to_s
+        end
+      ensure
+        buf.free!
       end
     end
 
@@ -168,6 +184,31 @@ module Fiddle
       ptr.free = free
 
       assert_equal free.ptr, ptr.free.ptr
+    end
+
+    def test_free!
+      ptr = Pointer.malloc(4)
+      refute ptr.freed?
+      ptr.free!
+      assert ptr.freed?
+      ptr.free!                 # you can safely run it again
+      assert ptr.freed?
+
+      ptr = Pointer.malloc(4, Fiddle::RUBY_FREE)
+      refute ptr.freed?
+      ptr.free!
+      assert ptr.freed?
+      ptr.free!                 # you can safely run it again
+      assert ptr.freed?
+      GC.start                  # you can safely run the GC routine
+      assert ptr.freed?
+    end
+
+    def test_freed?
+      ptr = Pointer.malloc(4)
+      refute ptr.freed?
+      ptr.free!
+      assert ptr.freed?
     end
 
     def test_null?

--- a/test/fiddle/test_pointer.rb
+++ b/test/fiddle/test_pointer.rb
@@ -20,7 +20,6 @@ module Fiddle
       assert_equal free.to_i, Fiddle::RUBY_FREE.to_i
 
       ptr  = Pointer.malloc(10, free.to_i)
-      refute ptr.freed?
       begin
         assert_equal 10, ptr.size
         assert_equal free.to_i, ptr.free.to_i
@@ -186,14 +185,7 @@ module Fiddle
       assert_equal free.ptr, ptr.free.ptr
     end
 
-    def test_free!
-      ptr = Pointer.malloc(4)
-      refute ptr.freed?
-      ptr.free!
-      refute ptr.freed?
-      ptr.free!                 # you can safely run it again
-      refute ptr.freed?
-
+    def test_free_with_func
       ptr = Pointer.malloc(4, Fiddle::RUBY_FREE)
       refute ptr.freed?
       ptr.free!
@@ -202,6 +194,15 @@ module Fiddle
       assert ptr.freed?
       GC.start                  # you can safely run the GC routine
       assert ptr.freed?
+    end
+
+    def test_free_with_no_func
+      ptr = Pointer.malloc(4)
+      refute ptr.freed?
+      ptr.free!
+      refute ptr.freed?
+      ptr.free!                 # you can safely run it again
+      refute ptr.freed?
     end
 
     def test_freed?

--- a/test/fiddle/test_pointer.rb
+++ b/test/fiddle/test_pointer.rb
@@ -190,9 +190,9 @@ module Fiddle
       ptr = Pointer.malloc(4)
       refute ptr.freed?
       ptr.free!
-      assert ptr.freed?
+      refute ptr.freed?
       ptr.free!                 # you can safely run it again
-      assert ptr.freed?
+      refute ptr.freed?
 
       ptr = Pointer.malloc(4, Fiddle::RUBY_FREE)
       refute ptr.freed?
@@ -205,7 +205,7 @@ module Fiddle
     end
 
     def test_freed?
-      ptr = Pointer.malloc(4)
+      ptr = Pointer.malloc(4, Fiddle::RUBY_FREE)
       refute ptr.freed?
       ptr.free!
       assert ptr.freed?


### PR DESCRIPTION
`free!` runs the user's free function. It doesn't do anything if the pointer has already been freed. The GC won't call the user's free function if the user already manually freed. Another method `freed?` tells the user if the pointer has already been freed.

All together, these changes allow you to rely on the GC to definitely free your memory, meaning no leaks, but then also allows you to manually free as early as possible if you can, meaning deterministic deallocation, improving cache locality and and reducing peaks in memory use.