### PR TITLE
Fix Actions - test step - --disable=gems

### DIFF
--- a/.github/workflows/fiddle.yml
+++ b/.github/workflows/fiddle.yml
@@ -37,6 +37,8 @@ jobs:
         run:  rake install
 
       - name: rake test
+        env:
+          RUBYOPT: --disable=gems
         run:  |
           ruby -v
           rake test


### PR DESCRIPTION
Since we're testing a default gem, disabling RubyGems is probably a good idea, especially since the test files are vendored.

Also, MinGW build's devkit requires fiddle, so that causes issues.