### PR TITLE
Structured memory deallocation using blocks

### DIFF
--- a/ext/fiddle/pointer.c
+++ b/ext/fiddle/pointer.c
@@ -272,8 +272,8 @@ rb_fiddle_ptr_s_malloc(int argc, VALUE argv[], VALUE klass)
     if (wrap) RPTR_DATA(obj)->wrap[1] = wrap;
 
     if (rb_block_given_p()) {
-        if (f == NULL) {
-            rb_raise(rb_eFiddleError, "a free function must be supplied to Fiddle::Pointer.malloc when it is called with a block");
+        if (!f) {
+            rb_raise(rb_eArgError, "a free function must be supplied to Fiddle::Pointer.malloc when it is called with a block");
         }
         return rb_ensure(rb_yield, obj, rb_fiddle_ptr_call_free, obj);
     } else {

--- a/test/fiddle/test_c_struct_entry.rb
+++ b/test/fiddle/test_c_struct_entry.rb
@@ -57,21 +57,24 @@ module Fiddle
     def test_aref_pointer_array
       team = CStructEntity.malloc([[TYPE_VOIDP, 2]], Fiddle::RUBY_FREE)
       team.assign_names(["names"])
-      alice = Fiddle::Pointer.malloc(6, Fiddle::RUBY_FREE)
-      alice[0, 6] = "Alice\0"
-      bob = Fiddle::Pointer.malloc(4, Fiddle::RUBY_FREE)
-      bob[0, 4] = "Bob\0"
-      team["names"] = [alice, bob]
-      assert_equal(["Alice", "Bob"], team["names"].map(&:to_s))
+      Fiddle::Pointer.malloc(6, Fiddle::RUBY_FREE) do |alice|
+        alice[0, 6] = "Alice\0"
+        Fiddle::Pointer.malloc(4, Fiddle::RUBY_FREE) do |bob|
+          bob[0, 4] = "Bob\0"
+          team["names"] = [alice, bob]
+          assert_equal(["Alice", "Bob"], team["names"].map(&:to_s))
+        end
+      end
     end
 
     def test_aref_pointer
       user = CStructEntity.malloc([TYPE_VOIDP], Fiddle::RUBY_FREE)
       user.assign_names(["name"])
-      alice = Fiddle::Pointer.malloc(6, Fiddle::RUBY_FREE)
-      alice[0, 6] = "Alice\0"
-      user["name"] = alice
-      assert_equal("Alice", user["name"].to_s)
+      Fiddle::Pointer.malloc(6, Fiddle::RUBY_FREE) do |alice|
+        alice[0, 6] = "Alice\0"
+        user["name"] = alice
+        assert_equal("Alice", user["name"].to_s)
+      end
     end
   end
 end if defined?(Fiddle)

--- a/test/fiddle/test_pointer.rb
+++ b/test/fiddle/test_pointer.rb
@@ -32,6 +32,24 @@ module Fiddle
       assert_equal free.to_i, ptr.free.to_i
     end
 
+    def test_malloc_block
+      escaped_ptr = nil
+      returned = Pointer.malloc(10, Fiddle::RUBY_FREE) do |ptr|
+        assert_equal 10, ptr.size
+        assert_equal Fiddle::RUBY_FREE, ptr.free.to_i
+        escaped_ptr = ptr
+        :returned
+      end
+      assert_equal :returned, returned
+      assert escaped_ptr.freed?
+    end
+
+    def test_malloc_block_no_free
+      assert_raise Fiddle::DLError do 
+        Pointer.malloc(10) { |ptr| raise }
+      end
+    end
+
     def test_to_str
       str = Marshal.load(Marshal.dump("hello world"))
       ptr = Pointer[str]

--- a/test/fiddle/test_pointer.rb
+++ b/test/fiddle/test_pointer.rb
@@ -102,17 +102,18 @@ module Fiddle
     end
 
     def test_to_ptr_io
-      buf = Pointer.malloc(10, Fiddle::RUBY_FREE)
-      File.open(__FILE__, 'r') do |f|
-        ptr = Pointer.to_ptr f
-        fread = Function.new(@libc['fread'],
-                             [TYPE_VOIDP, TYPE_INT, TYPE_INT, TYPE_VOIDP],
-                             TYPE_INT)
-        fread.call(buf.to_i, Fiddle::SIZEOF_CHAR, buf.size - 1, ptr.to_i)
-      end
+      Pointer.malloc(10, Fiddle::RUBY_FREE) do |buf|
+        File.open(__FILE__, 'r') do |f|
+          ptr = Pointer.to_ptr f
+          fread = Function.new(@libc['fread'],
+                              [TYPE_VOIDP, TYPE_INT, TYPE_INT, TYPE_VOIDP],
+                              TYPE_INT)
+          fread.call(buf.to_i, Fiddle::SIZEOF_CHAR, buf.size - 1, ptr.to_i)
+        end
 
-      File.open(__FILE__, 'r') do |f|
-        assert_equal f.read(9), buf.to_s
+        File.open(__FILE__, 'r') do |f|
+          assert_equal f.read(9), buf.to_s
+        end
       end
     end
 
@@ -195,7 +196,7 @@ module Fiddle
       assert ptr.freed?
       ptr.call_free                 # you can safely run it again
       assert ptr.freed?
-      GC.start                  # you can safely run the GC routine
+      GC.start                      # you can safely run the GC routine
       assert ptr.freed?
     end
 
@@ -221,21 +222,15 @@ module Fiddle
     end
 
     def test_size
-      ptr = Pointer.malloc(4)
-      begin
+      Pointer.malloc(4, Fiddle::RUBY_FREE) do |ptr|
         assert_equal 4, ptr.size
-      ensure
-        Fiddle.free ptr
       end
     end
 
     def test_size=
-      ptr = Pointer.malloc(4)
-      begin
+      Pointer.malloc(4, Fiddle::RUBY_FREE) do |ptr|
         ptr.size = 10
         assert_equal 10, ptr.size
-      ensure
-        Fiddle.free ptr
       end
     end
 

--- a/test/fiddle/test_pointer.rb
+++ b/test/fiddle/test_pointer.rb
@@ -45,8 +45,8 @@ module Fiddle
     end
 
     def test_malloc_block_no_free
-      assert_raise Fiddle::DLError do 
-        Pointer.malloc(10) { |ptr| raise }
+      assert_raise ArgumentError do 
+        Pointer.malloc(10) { |ptr| }
       end
     end
 


### PR DESCRIPTION
```ruby
Fiddle::Pointer.new(size, free) do |pointer|
  ...
end
```

* Easy to use best-practice
* Helps people write correct code for the most common cases
* Protect against leaks (free if there's an exception, or even if someone uses a trace point to get hold of the object)
* Protect against deallocation latency (free as soon as you're done)
* Protect against non-locality (free while it's still in cache from your using it)