### PR TITLE
mswin CI job doesn't work - remove it

### DIFF
--- a/.github/workflows/fiddle.yml
+++ b/.github/workflows/fiddle.yml
@@ -14,7 +14,7 @@ jobs:
         ruby: [ 2.3, 2.4, 2.5, 2.6, 2.7, head ]
         include:
           - { os: windows , ruby: mingw }
-          - { os: windows , ruby: mswin }
+          # - { os: windows , ruby: mswin } this fails with missing libffi
         exclude:
           - { os: windows , ruby: head }
 


### PR DESCRIPTION
Can we remove this failing job, and put it back in a PR where we get it working before merging it?