### PR TITLE
Warn against using Fiddle::Function to call C extension APIs

### DIFF
--- a/ext/fiddle/function.c
+++ b/ext/fiddle/function.c
@@ -432,6 +432,8 @@ Init_fiddle_function(void)
      * Calls the constructed Function, with +args+.
      * Caller must ensure the underlying function is called in a
      * thread-safe manner if running in a multi-threaded process.
+     * Note that it is not thread-safe to use this method to
+     * directly or indirectly call many Ruby C-extension APIs.
      *
      * For an example see Fiddle::Function
      *


### PR DESCRIPTION
Since Fiddle::Function releases the GVL when making the call, it's not
thread-safe to use it to call a lot of Ruby's C extension APIs.

---

I want to warn against this because I had to debug a thread safety issue caused by this. [Rutie](https://github.com/danielpclark/rutie) uses Fiddle to call the init function of C extensions that it produces, which is not thread-safe without the GVL.

See:
https://github.com/danielpclark/rutie/blob/master/examples/rutie_ruby_gvl_example/lib/rutie_ruby_gvl_example.rb#L5
https://github.com/danielpclark/rutie-gem/blob/ffaba4689f351a0acaf84067a6fca5c3b65bc9aa/lib/rutie.rb#L21