### PR TITLE
Use libSystem.B.dylib instead of libm.dylib and libc.dylib

### DIFF
--- a/test/fiddle/helper.rb
+++ b/test/fiddle/helper.rb
@@ -55,8 +55,7 @@ when /mingw/, /mswin/
   crtname = RbConfig::CONFIG["RUBY_SO_NAME"][/msvc\w+/] || 'ucrtbase'
   libc_so = libm_so = "#{crtname}.dll"
 when /darwin/
-  libc_so = "libc.dylib"
-  libm_so = "libm.dylib"
+  libc_so = libm_so = "/usr/lib/libSystem.B.dylib"
 when /kfreebsd/
   libc_so = "/lib/libc.so.0.1"
   libm_so = "/lib/libm.so.1"
@@ -122,6 +121,11 @@ end
 
 libc_so = nil if !libc_so || (libc_so[0] == ?/ && !File.file?(libc_so))
 libm_so = nil if !libm_so || (libm_so[0] == ?/ && !File.file?(libm_so))
+
+# macOS 11.0+ removed libSystem.B.dylib from /usr/lib. But It works with dlopen.
+if RUBY_PLATFORM =~ /darwin/
+  libc_so = libm_so = "/usr/lib/libSystem.B.dylib"
+end
 
 if !libc_so || !libm_so
   ruby = EnvUtil.rubybin


### PR DESCRIPTION
Because macOS 11.0(Big Sur) was removed libc and libm from `/usr/lib`.

~https://github.com/ruby/ruby/commit/bd47a8d660~
https://github.com/ruby/ruby/commit/b7d86e330c
https://github.com/ruby/ruby/commit/cdef17096c
https://github.com/ruby/ruby/commit/0168094da2