### PR TITLE
Remove -I$(top_srcdir)

### DIFF
--- a/ext/fiddle/extconf.rb
+++ b/ext/fiddle/extconf.rb
@@ -181,7 +181,6 @@ if libffi
   $LOCAL_LIBS.prepend("./#{libffi.a} ").strip! # to exts.mk
   $INCFLAGS.gsub!(/-I#{libffi.dir}/, '-I$(LIBFFI_DIR)')
 end
-$INCFLAGS << " -I$(top_srcdir)"
 create_makefile 'fiddle' do |conf|
   if !libffi
     next conf << "LIBFFI_CLEAN = none\n"


### PR DESCRIPTION
`-I$(top_srcdir)` is unnecessary because fiddle no longer depends on ruby's internal.h.

`top_srcdir` is not defined when fiddle will be installed as a gem.  In that situation, `-I$(top_srcdir)` turns to be `-I`, so the next compiler option is consumed as an argument of `-I`.