### PR TITLE
Refactored parse_signature

### DIFF
--- a/lib/fiddle/cparser.rb
+++ b/lib/fiddle/cparser.rb
@@ -108,16 +108,15 @@ module Fiddle
     #
     def parse_signature(signature, tymap=nil)
       tymap ||= {}
-      case compact(signature)
-      when /^(?:[\w\*\s]+)\(\*(\w+)\((.*?)\)\)(?:\[\w*\]|\(.*?\));?$/
-        func, args = $1, $2
-        return [func, TYPE_VOIDP, split_arguments(args).collect {|arg| parse_ctype(arg, tymap)}]
-      when /^([\w\*\s]+[\*\s])(\w+)\((.*?)\);?$/
-        ret, func, args = $1.strip, $2, $3
-        return [func, parse_ctype(ret, tymap), split_arguments(args).collect {|arg| parse_ctype(arg, tymap)}]
-      else
-        raise(RuntimeError,"can't parse the function prototype: #{signature}")
-      end
+      ret, func, args = case compact(signature)
+                        when /^(?:[\w*\s]+)\(\*(\w+)\((.*?)\)\)(?:\[\w*\]|\(.*?\));?$/
+                          [TYPE_VOIDP, $1, $2]
+                        when /^([\w*\s]+[*\s])(\w+)\((.*?)\);?$/
+                          [$1.strip, $2, $3]
+                        else
+                          raise("can't parse the function prototype: #{signature}")
+                        end
+      [func, parse_ctype(ret, tymap), split_arguments(args).collect {|arg| parse_ctype(arg, tymap)}]
     end
 
     # Given a String of C type +ty+, returns the corresponding Fiddle constant.


### PR DESCRIPTION
This is just an idea.
A proposal to improve the parse_signature method.

Background:
I wanted to parse_signature recursively when the argument was a function (i.e. a function pointer).
When I wrote a monkey patch for it, I noticed that parse_signature was unnecessarily complicated.

1. Line 114 and line 117 are almost the same code.
2. Each line is unnecessarily long.
3. Some variable names are confusing.
4. Also, the variables $1, $2, etc. looks old-fashioned.

2 - 4 are more of a library-wide issue, and are my personal opinions rather than objective facts.
Libraries have their own history.

Here, I am focusing on 1.

Please feel free to close this.
Thank you.