### PR TITLE
Update required_ruby_version

### DIFF
--- a/fiddle.gemspec
+++ b/fiddle.gemspec
@@ -56,7 +56,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
   spec.extensions = ["ext/fiddle/extconf.rb"]
 
-  spec.required_ruby_version = ">= 2.3.0"
+  spec.required_ruby_version = ">= 2.5.0"
 
   spec.add_development_dependency "bundler"
   spec.add_development_dependency "rake"


### PR DESCRIPTION
Drop supports for old versions, keeping 2.5 as CI supports it for now.