### PR TITLE
Check HAVE_RUBY_MEMORY_VIEW_H rather than API version

### DIFF
--- a/ext/-test-/memory_view/extconf.rb
+++ b/ext/-test-/memory_view/extconf.rb
@@ -1,9 +1,5 @@
 # frozen_string_literal: false
 require "mkmf"
 
-if have_header("ruby/memory_view.h")
-  have_type("rb_memory_view_t", ["ruby/memory_view.h"])
-end
-
 require_relative "../auto_ext.rb"
 auto_ext(inc: true)

--- a/ext/-test-/memory_view/memory_view.c
+++ b/ext/-test-/memory_view/memory_view.c
@@ -1,6 +1,6 @@
-#ifdef HAVE_RUBY_MEMORY_VIEW_H
-
 #include "ruby.h"
+
+#ifdef HAVE_RUBY_MEMORY_VIEW_H
 #include "ruby/memory_view.h"
 
 #define STRUCT_ALIGNOF(T, result) do { \

--- a/ext/-test-/memory_view/memory_view.c
+++ b/ext/-test-/memory_view/memory_view.c
@@ -1,4 +1,4 @@
-#ifdef HAVE_TYPE_RB_MEMORY_VIEW_T
+#ifdef HAVE_RUBY_MEMORY_VIEW_H
 
 #include "ruby.h"
 #include "ruby/memory_view.h"
@@ -378,12 +378,12 @@ mdview_aref(VALUE obj, VALUE indices_v)
     return result;
 }
 
-#endif /* HAVE_TYPE_RB_MEMORY_VIEW_T */
+#endif /* HAVE_RUBY_MEMORY_VIEW_H */
 
 void
 Init_memory_view(void)
 {
-#ifdef HAVE_TYPE_RB_MEMORY_VIEW_T
+#ifdef HAVE_RUBY_MEMORY_VIEW_H
     VALUE mMemoryViewTestUtils = rb_define_module("MemoryViewTestUtils");
 
     rb_define_module_function(mMemoryViewTestUtils, "available?", memory_view_available_p, 1);
@@ -448,5 +448,5 @@ Init_memory_view(void)
 
 #undef DEF_ALIGNMENT_CONST
 
-#endif /* HAVE_TYPE_RB_MEMORY_VIEW_T */
+#endif /* HAVE_RUBY_MEMORY_VIEW_H */
 }

--- a/ext/fiddle/fiddle.c
+++ b/ext/fiddle/fiddle.c
@@ -7,7 +7,7 @@ VALUE rb_eFiddleError;
 void Init_fiddle_pointer(void);
 void Init_fiddle_pinned(void);
 
-#ifdef FIDDLE_MEMORY_VIEW
+#ifdef HAVE_RUBY_MEMORY_VIEW_H
 void Init_fiddle_memory_view(void);
 #endif
 
@@ -546,7 +546,7 @@ Init_fiddle(void)
     Init_fiddle_pointer();
     Init_fiddle_pinned();
 
-#ifdef FIDDLE_MEMORY_VIEW
+#ifdef HAVE_RUBY_MEMORY_VIEW_H
     Init_fiddle_memory_view();
 #endif
 }

--- a/ext/fiddle/fiddle.h
+++ b/ext/fiddle/fiddle.h
@@ -189,10 +189,6 @@
 #define ALIGN_INT32_T ALIGN_OF(int32_t)
 #define ALIGN_INT64_T ALIGN_OF(int64_t)
 
-#ifdef HAVE_RUBY_MEMORY_VIEW_H
-# define FIDDLE_MEMORY_VIEW
-#endif
-
 extern VALUE mFiddle;
 extern VALUE rb_eFiddleDLError;
 

--- a/ext/fiddle/fiddle.h
+++ b/ext/fiddle/fiddle.h
@@ -2,7 +2,6 @@
 #define FIDDLE_H
 
 #include <ruby.h>
-#include <ruby/version.h>
 #include <errno.h>
 
 #if defined(_WIN32)
@@ -190,7 +189,7 @@
 #define ALIGN_INT32_T ALIGN_OF(int32_t)
 #define ALIGN_INT64_T ALIGN_OF(int64_t)
 
-#if RUBY_API_VERSION_MAJOR >= 3
+#ifdef HAVE_RUBY_MEMORY_VIEW_H
 # define FIDDLE_MEMORY_VIEW
 #endif
 

--- a/ext/fiddle/memory_view.c
+++ b/ext/fiddle/memory_view.c
@@ -1,6 +1,6 @@
 #include <fiddle.h>
 
-#ifdef FIDDLE_MEMORY_VIEW
+#ifdef HAVE_RUBY_MEMORY_VIEW_H
 
 #include <stdbool.h>
 #include <ruby/ruby.h>
@@ -318,4 +318,4 @@ Init_fiddle_memory_view(void)
     rb_define_method(rb_cMemoryView, "to_s", rb_fiddle_memview_to_s, 0);
 }
 
-#endif /* FIDDLE_MEMORY_VIEW */
+#endif /* HAVE_RUBY_MEMORY_VIEW_H */

--- a/ext/fiddle/pointer.c
+++ b/ext/fiddle/pointer.c
@@ -9,7 +9,7 @@
 #include <ctype.h>
 #include <fiddle.h>
 
-#ifdef FIDDLE_MEMORY_VIEW
+#ifdef HAVE_RUBY_MEMORY_VIEW_H
 # include <ruby/memory_view.h>
 #endif
 
@@ -92,7 +92,7 @@ static const rb_data_type_t fiddle_ptr_data_type = {
     {fiddle_ptr_mark, fiddle_ptr_free, fiddle_ptr_memsize,},
 };
 
-#ifdef FIDDLE_MEMORY_VIEW
+#ifdef HAVE_RUBY_MEMORY_VIEW_H
 static struct ptr_data *
 fiddle_ptr_check_memory_view(VALUE obj)
 {
@@ -833,7 +833,7 @@ Init_fiddle_pointer(void)
     rb_define_method(rb_cPointer, "size", rb_fiddle_ptr_size_get, 0);
     rb_define_method(rb_cPointer, "size=", rb_fiddle_ptr_size_set, 1);
 
-#ifdef FIDDLE_MEMORY_VIEW
+#ifdef HAVE_RUBY_MEMORY_VIEW_H
     rb_memory_view_register(rb_cPointer, &fiddle_ptr_memory_view_entry);
 #endif
 


### PR DESCRIPTION
These macros are defined for exactly this purpose.