### PR TITLE
Return the module handle value in Fiddle::Handle#to_i

### DIFF
--- a/ext/fiddle/fiddle.h
+++ b/ext/fiddle/fiddle.h
@@ -199,5 +199,8 @@ extern VALUE rb_eFiddleDLError;
 
 VALUE rb_fiddle_new_function(VALUE address, VALUE arg_types, VALUE ret_type);
 
+typedef void (*rb_fiddle_freefunc_t)(void*);
+VALUE rb_fiddle_ptr_new_wrap(void *ptr, long size, rb_fiddle_freefunc_t func, VALUE wrap0, VALUE wrap1);
+
 #endif
 /* vim: set noet sws=4 sw=4: */

--- a/ext/fiddle/handle.c
+++ b/ext/fiddle/handle.c
@@ -259,7 +259,7 @@ rb_fiddle_handle_to_i(VALUE self)
     struct dl_handle *fiddle_handle;
 
     TypedData_Get_Struct(self, struct dl_handle, &fiddle_handle_data_type, fiddle_handle);
-    return PTR2NUM(fiddle_handle);
+    return PTR2NUM(fiddle_handle->ptr);
 }
 
 static VALUE fiddle_handle_sym(void *handle, VALUE symbol);

--- a/ext/fiddle/handle.c
+++ b/ext/fiddle/handle.c
@@ -262,6 +262,20 @@ rb_fiddle_handle_to_i(VALUE self)
     return PTR2NUM(fiddle_handle->ptr);
 }
 
+/*
+ * call-seq: to_ptr
+ *
+ * Returns the Fiddle::Pointer of this handle.
+ */
+static VALUE
+rb_fiddle_handle_to_ptr(VALUE self)
+{
+    struct dl_handle *fiddle_handle;
+
+    TypedData_Get_Struct(self, struct dl_handle, &fiddle_handle_data_type, fiddle_handle);
+    return rb_fiddle_ptr_new_wrap(fiddle_handle->ptr, 0, 0, self, 0);
+}
+
 static VALUE fiddle_handle_sym(void *handle, VALUE symbol);
 
 /*
@@ -466,6 +480,7 @@ Init_fiddle_handle(void)
 
     rb_define_method(rb_cHandle, "initialize", rb_fiddle_handle_initialize, -1);
     rb_define_method(rb_cHandle, "to_i", rb_fiddle_handle_to_i, 0);
+    rb_define_method(rb_cHandle, "to_ptr", rb_fiddle_handle_to_ptr, 0);
     rb_define_method(rb_cHandle, "close", rb_fiddle_handle_close, 0);
     rb_define_method(rb_cHandle, "sym",  rb_fiddle_handle_sym, 1);
     rb_define_method(rb_cHandle, "[]",  rb_fiddle_handle_sym,  1);

--- a/ext/fiddle/pointer.c
+++ b/ext/fiddle/pointer.c
@@ -24,7 +24,7 @@
 
 VALUE rb_cPointer;
 
-typedef void (*freefunc_t)(void*);
+typedef rb_fiddle_freefunc_t freefunc_t;
 
 struct ptr_data {
     void *ptr;
@@ -125,7 +125,7 @@ static const rb_memory_view_entry_t fiddle_ptr_memory_view_entry = {
 #endif
 
 static VALUE
-rb_fiddle_ptr_new2(VALUE klass, void *ptr, long size, freefunc_t func)
+rb_fiddle_ptr_new2(VALUE klass, void *ptr, long size, freefunc_t func, VALUE wrap0, VALUE wrap1)
 {
     struct ptr_data *data;
     VALUE val;
@@ -135,14 +135,22 @@ rb_fiddle_ptr_new2(VALUE klass, void *ptr, long size, freefunc_t func)
     data->free = func;
     data->freed = false;
     data->size = size;
+    data->wrap[0] = wrap0;
+    data->wrap[1] = wrap1;
 
     return val;
+}
+
+VALUE
+rb_fiddle_ptr_new_wrap(void *ptr, long size, freefunc_t func, VALUE wrap0, VALUE wrap1)
+{
+    return rb_fiddle_ptr_new2(rb_cPointer, ptr, size, func, wrap0, wrap1);
 }
 
 static VALUE
 rb_fiddle_ptr_new(void *ptr, long size, freefunc_t func)
 {
-    return rb_fiddle_ptr_new2(rb_cPointer, ptr, size, func);
+    return rb_fiddle_ptr_new2(rb_cPointer, ptr, size, func, 0, 0);
 }
 
 static VALUE
@@ -152,7 +160,7 @@ rb_fiddle_ptr_malloc(VALUE klass, long size, freefunc_t func)
 
     ptr = ruby_xmalloc((size_t)size);
     memset(ptr,0,(size_t)size);
-    return rb_fiddle_ptr_new2(klass, ptr, size, func);
+    return rb_fiddle_ptr_new2(klass, ptr, size, func, 0, 0);
 }
 
 static void *

--- a/test/fiddle/test_handle.rb
+++ b/test/fiddle/test_handle.rb
@@ -13,6 +13,12 @@ module Fiddle
       assert_kind_of Integer, handle.to_i
     end
 
+    def test_to_ptr
+      handle = Fiddle::Handle.new(LIBC_SO)
+      ptr = handle.to_ptr
+      assert_equal ptr.to_i, handle.to_i
+    end
+
     def test_static_sym_unknown
       assert_raise(DLError) { Fiddle::Handle.sym('fooo') }
       assert_raise(DLError) { Fiddle::Handle['fooo'] }


### PR DESCRIPTION
`Fiddle::Handle#to_i` currently returns the address of the value of the module handle, that is `&fiddle_handle->ptr`.
I guess it is more useful than now that it returns the value of the module handle directly.
