### PR TITLE
version.rb - increment for ruby master builds

### DIFF
--- a/lib/fiddle/version.rb
+++ b/lib/fiddle/version.rb
@@ -1,3 +1,3 @@
 module Fiddle
-  VERSION = "1.1.0"
+  VERSION = "1.1.1"
 end


### PR DESCRIPTION
Ruby master builds have issues with installing an (extension?) gem when it is a default gem and the version matches the installed version.

Increment the version so master builds pass.

