### PR TITLE
Improve "offsetof" calculations

### DIFF
--- a/test/fiddle/test_c_struct_builder.rb
+++ b/test/fiddle/test_c_struct_builder.rb
@@ -3,12 +3,45 @@ begin
   require_relative 'helper'
   require 'fiddle/struct'
   require 'fiddle/cparser'
+  require 'fiddle/import'
 rescue LoadError
 end
 
 module Fiddle
   class TestCStructBuilder < TestCase
     include Fiddle::CParser
+    extend Fiddle::Importer
+
+    RBasic = struct ['void * flags',
+                     'void * klass' ]
+
+
+    RObject = struct [
+      { 'basic' => RBasic },
+      { 'as'    => union([
+                          { 'heap'=> struct([ 'uint32_t numiv',
+                                              'void * ivptr',
+                                              'void * iv_index_tbl' ]) },
+                             'void *ary[3]' ])}
+    ]
+
+
+    def test_basic_embedded_members
+      assert_equal 0, RObject.offsetof("basic.flags")
+      assert_equal Fiddle::SIZEOF_VOIDP, RObject.offsetof("basic.klass")
+    end
+
+    def test_embedded_union_members
+      assert_equal 2 * Fiddle::SIZEOF_VOIDP, RObject.offsetof("as")
+      assert_equal 2 * Fiddle::SIZEOF_VOIDP, RObject.offsetof("as.heap")
+      assert_equal 2 * Fiddle::SIZEOF_VOIDP, RObject.offsetof("as.heap.numiv")
+      assert_equal 3 * Fiddle::SIZEOF_VOIDP, RObject.offsetof("as.heap.ivptr")
+      assert_equal 4 * Fiddle::SIZEOF_VOIDP, RObject.offsetof("as.heap.iv_index_tbl")
+    end
+
+    def test_as_ary
+      assert_equal 2 * Fiddle::SIZEOF_VOIDP, RObject.offsetof("as.ary")
+    end
 
     def test_offsetof
       types, members = parse_struct_signature(['int64_t i','char c'])


### PR DESCRIPTION
I need to get the offset of members inside sub structures.  This patch
adds sub-structure offset support for structs.