### PR TITLE
Add CI steps for `--enable-bundled-libffi`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,6 +12,9 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
+        build_flags:
+          - ""
+          - " -- --enable-bundled-libffi"
         os:
           - macos-10.15
           - macos-11.0
@@ -40,7 +43,7 @@ jobs:
 
       - run: bundle install
 
-      - run: rake compile
+      - run: rake compile ${{ matrix.build_flags }}
 
       # If Fiddle in Ruby's master has the same version of this Fiddle,
       # "gem install pkg/*.gem" fails.


### PR DESCRIPTION
@hsbt reported an issue with `--enable-bundled-libffi` [here](https://bugs.ruby-lang.org/issues/18034).

I added a build that uses this flag, and that build is failing.  I was able to reproduce @hsbt's issue.  I think it's caused by libffi installed with homebrew *and* using the `--enable-bundled-libffi` flag.  My guess is that building the bundled libffi is failing, but the gem still compiles with the bundled ffi headers but links against the homebrew libffi.

I'm not sure how to fix yet, but I wanted to send this PR to show the issue.