### PR TITLE
Enabled `--enabled-bundled-ffi` option for only mswin environment

### DIFF
--- a/ext/fiddle/extconf.rb
+++ b/ext/fiddle/extconf.rb
@@ -46,7 +46,7 @@ end
 
 libffi_version = nil
 have_libffi = false
-bundle = enable_config('bundled-libffi')
+bundle = enable_config('bundled-libffi') && $mswin
 unless bundle
   dir_config 'libffi'
 


### PR DESCRIPTION
We discussed at https://bugs.ruby-lang.org/issues/18034