### PR TITLE
Update CParser#parse_struct_signature to support "int long blah"

### DIFF
--- a/lib/fiddle/cparser.rb
+++ b/lib/fiddle/cparser.rb
@@ -66,12 +66,12 @@ module Fiddle
             mems.push([struct_name, struct_type.members])
             tys.push(ty)
           end
-        when /^[\w\*\s]+[\*\s](\w+)$/
-          mems.push($1)
-          tys.push(parse_ctype(msig, tymap))
-        when /^[\w\*\s]+\(\*(\w+)\)\(.*?\)$/
-          mems.push($1)
-          tys.push(parse_ctype(msig, tymap))
+        when /^([\w\*\s]+[\*\s])(\w+)$/
+          mems.push($2)
+          tys.push(parse_ctype($1, tymap))
+        when /^([\w\*\s]+)\(\*(\w+)\)\(.*?\)$/
+          mems.push($2)
+          tys.push(parse_ctype($1, tymap))
         when /^([\w\*\s]+[\*\s])(\w+)\[(\d+)\]$/
           mems.push($2)
           tys.push([parse_ctype($1.strip, tymap), $3.to_i])

--- a/test/fiddle/test_cparser.rb
+++ b/test/fiddle/test_cparser.rb
@@ -245,6 +245,18 @@ module Fiddle
       assert_equal [[TYPE_INT,-TYPE_LONG], ['i', 'cb']], parse_struct_signature(['int i', 'DWORD cb'], {"DWORD" => "unsigned long"})
     end
 
+    # verify fix for #100
+    def test_struct_int_long
+      assert_equal([[TYPE_LONG], ['len']],
+                   parse_struct_signature(['int long len']))
+    end
+
+    def test_struct_int_long
+      assert_equal([[TYPE_LONG], ['func']],
+                   parse_struct_signature(['int long (*func)(void)']))
+    end
+
+
     def test_signature_basic
       func, ret, args = parse_signature('void func()')
       assert_equal 'func', func


### PR DESCRIPTION
fixes #100 

(was hoping this would run the pipeline, but no luck; I'll find a way to run the tests)