### PR TITLE
Add constants for unsigned values

### DIFF
--- a/ext/fiddle/closure.c
+++ b/ext/fiddle/closure.c
@@ -92,7 +92,7 @@ with_gvl_callback(void *ptr)
 	  case TYPE_INT:
 	    rb_ary_push(params, INT2NUM(*(int *)x->args[i]));
 	    break;
-	  case -TYPE_INT:
+	  case TYPE_UINT:
 	    rb_ary_push(params, UINT2NUM(*(unsigned int *)x->args[i]));
 	    break;
 	  case TYPE_VOIDP:
@@ -103,19 +103,19 @@ with_gvl_callback(void *ptr)
 	  case TYPE_LONG:
 	    rb_ary_push(params, LONG2NUM(*(long *)x->args[i]));
 	    break;
-	  case -TYPE_LONG:
+	  case TYPE_ULONG:
 	    rb_ary_push(params, ULONG2NUM(*(unsigned long *)x->args[i]));
 	    break;
 	  case TYPE_CHAR:
 	    rb_ary_push(params, INT2NUM(*(signed char *)x->args[i]));
 	    break;
-	  case -TYPE_CHAR:
+	  case TYPE_UCHAR:
 	    rb_ary_push(params, UINT2NUM(*(unsigned char *)x->args[i]));
 	    break;
 	  case TYPE_SHORT:
 	    rb_ary_push(params, INT2NUM(*(signed short *)x->args[i]));
 	    break;
-	  case -TYPE_SHORT:
+	  case TYPE_USHORT:
 	    rb_ary_push(params, UINT2NUM(*(unsigned short *)x->args[i]));
 	    break;
 	  case TYPE_DOUBLE:
@@ -128,7 +128,7 @@ with_gvl_callback(void *ptr)
 	  case TYPE_LONG_LONG:
 	    rb_ary_push(params, LL2NUM(*(LONG_LONG *)x->args[i]));
 	    break;
-	  case -TYPE_LONG_LONG:
+	  case TYPE_ULONG_LONG:
 	    rb_ary_push(params, ULL2NUM(*(unsigned LONG_LONG *)x->args[i]));
 	    break;
 #endif
@@ -151,7 +151,7 @@ with_gvl_callback(void *ptr)
       case TYPE_LONG:
 	*(long *)x->resp = NUM2LONG(ret);
 	break;
-      case -TYPE_LONG:
+      case TYPE_ULONG:
 	*(unsigned long *)x->resp = NUM2ULONG(ret);
 	break;
       case TYPE_CHAR:
@@ -159,9 +159,9 @@ with_gvl_callback(void *ptr)
       case TYPE_INT:
 	*(ffi_sarg *)x->resp = NUM2INT(ret);
 	break;
-      case -TYPE_CHAR:
-      case -TYPE_SHORT:
-      case -TYPE_INT:
+      case TYPE_UCHAR:
+      case TYPE_USHORT:
+      case TYPE_UINT:
 	*(ffi_arg *)x->resp = NUM2UINT(ret);
 	break;
       case TYPE_VOIDP:
@@ -177,7 +177,7 @@ with_gvl_callback(void *ptr)
       case TYPE_LONG_LONG:
 	*(LONG_LONG *)x->resp = NUM2LL(ret);
 	break;
-      case -TYPE_LONG_LONG:
+      case TYPE_ULONG_LONG:
 	*(unsigned LONG_LONG *)x->resp = NUM2ULL(ret);
 	break;
 #endif

--- a/ext/fiddle/conversions.c
+++ b/ext/fiddle/conversions.c
@@ -211,32 +211,32 @@ rb_fiddle_value_to_generic(int type, VALUE *src, fiddle_generic *dst)
       case TYPE_CHAR:
 	dst->schar = (signed char)NUM2INT(*src);
 	break;
-      case -TYPE_CHAR:
+      case TYPE_UCHAR:
 	dst->uchar = (unsigned char)NUM2UINT(*src);
 	break;
       case TYPE_SHORT:
 	dst->sshort = (unsigned short)NUM2INT(*src);
 	break;
-      case -TYPE_SHORT:
+      case TYPE_USHORT:
 	dst->sshort = (signed short)NUM2UINT(*src);
 	break;
       case TYPE_INT:
 	dst->sint = NUM2INT(*src);
 	break;
-      case -TYPE_INT:
+      case TYPE_UINT:
 	dst->uint = NUM2UINT(*src);
 	break;
       case TYPE_LONG:
 	dst->slong = NUM2LONG(*src);
 	break;
-      case -TYPE_LONG:
+      case TYPE_ULONG:
 	dst->ulong = NUM2ULONG(*src);
 	break;
 #if HAVE_LONG_LONG
       case TYPE_LONG_LONG:
 	dst->slong_long = NUM2LL(*src);
 	break;
-      case -TYPE_LONG_LONG:
+      case TYPE_ULONG_LONG:
 	dst->ulong_long = NUM2ULL(*src);
 	break;
 #endif
@@ -283,24 +283,24 @@ rb_fiddle_generic_to_value(VALUE rettype, fiddle_generic retval)
           PTR2NUM((void *)retval.pointer));
       case TYPE_CHAR:
 	return INT2NUM((signed char)retval.fffi_sarg);
-      case -TYPE_CHAR:
+      case TYPE_UCHAR:
 	return INT2NUM((unsigned char)retval.fffi_arg);
       case TYPE_SHORT:
 	return INT2NUM((signed short)retval.fffi_sarg);
-      case -TYPE_SHORT:
+      case TYPE_USHORT:
 	return INT2NUM((unsigned short)retval.fffi_arg);
       case TYPE_INT:
 	return INT2NUM((signed int)retval.fffi_sarg);
-      case -TYPE_INT:
+      case TYPE_UINT:
 	return UINT2NUM((unsigned int)retval.fffi_arg);
       case TYPE_LONG:
 	return LONG2NUM(retval.slong);
-      case -TYPE_LONG:
+      case TYPE_ULONG:
 	return ULONG2NUM(retval.ulong);
 #if HAVE_LONG_LONG
       case TYPE_LONG_LONG:
 	return LL2NUM(retval.slong_long);
-      case -TYPE_LONG_LONG:
+      case TYPE_ULONG_LONG:
 	return ULL2NUM(retval.ulong_long);
 #endif
       case TYPE_FLOAT:

--- a/ext/fiddle/fiddle.c
+++ b/ext/fiddle/fiddle.c
@@ -182,11 +182,23 @@ Init_fiddle(void)
      */
     rb_define_const(mFiddle, "TYPE_CHAR",      INT2NUM(TYPE_CHAR));
 
+    /* Document-const: TYPE_UCHAR
+     *
+     * C type - unsigned char
+     */
+    rb_define_const(mFiddle, "TYPE_UCHAR",      INT2NUM(TYPE_UCHAR));
+
     /* Document-const: TYPE_SHORT
      *
      * C type - short
      */
     rb_define_const(mFiddle, "TYPE_SHORT",     INT2NUM(TYPE_SHORT));
+
+    /* Document-const: TYPE_USHORT
+     *
+     * C type - unsigned short
+     */
+    rb_define_const(mFiddle, "TYPE_USHORT",     INT2NUM(TYPE_USHORT));
 
     /* Document-const: TYPE_INT
      *
@@ -194,11 +206,23 @@ Init_fiddle(void)
      */
     rb_define_const(mFiddle, "TYPE_INT",       INT2NUM(TYPE_INT));
 
+    /* Document-const: TYPE_UINT
+     *
+     * C type - unsigned int
+     */
+    rb_define_const(mFiddle, "TYPE_UINT",       INT2NUM(TYPE_UINT));
+
     /* Document-const: TYPE_LONG
      *
      * C type - long
      */
     rb_define_const(mFiddle, "TYPE_LONG",      INT2NUM(TYPE_LONG));
+
+    /* Document-const: TYPE_ULONG
+     *
+     * C type - long
+     */
+    rb_define_const(mFiddle, "TYPE_ULONG",      INT2NUM(TYPE_ULONG));
 
 #if HAVE_LONG_LONG
     /* Document-const: TYPE_LONG_LONG
@@ -206,6 +230,12 @@ Init_fiddle(void)
      * C type - long long
      */
     rb_define_const(mFiddle, "TYPE_LONG_LONG", INT2NUM(TYPE_LONG_LONG));
+
+    /* Document-const: TYPE_ULONG_LONG
+     *
+     * C type - long long
+     */
+    rb_define_const(mFiddle, "TYPE_ULONG_LONG", INT2NUM(TYPE_ULONG_LONG));
 #endif
 
 #ifdef TYPE_INT8_T
@@ -214,6 +244,12 @@ Init_fiddle(void)
      * C type - int8_t
      */
     rb_define_const(mFiddle, "TYPE_INT8_T",    INT2NUM(TYPE_INT8_T));
+
+    /* Document-const: TYPE_UINT8_T
+     *
+     * C type - uint8_t
+     */
+    rb_define_const(mFiddle, "TYPE_UINT8_T",    INT2NUM(TYPE_UINT8_T));
 #endif
 
 #ifdef TYPE_INT16_T
@@ -222,6 +258,12 @@ Init_fiddle(void)
      * C type - int16_t
      */
     rb_define_const(mFiddle, "TYPE_INT16_T",   INT2NUM(TYPE_INT16_T));
+
+    /* Document-const: TYPE_UINT16_T
+     *
+     * C type - uint16_t
+     */
+    rb_define_const(mFiddle, "TYPE_UINT16_T",   INT2NUM(TYPE_UINT16_T));
 #endif
 
 #ifdef TYPE_INT32_T
@@ -230,6 +272,12 @@ Init_fiddle(void)
      * C type - int32_t
      */
     rb_define_const(mFiddle, "TYPE_INT32_T",   INT2NUM(TYPE_INT32_T));
+
+    /* Document-const: TYPE_UINT32_T
+     *
+     * C type - uint32_t
+     */
+    rb_define_const(mFiddle, "TYPE_UINT32_T",   INT2NUM(TYPE_UINT32_T));
 #endif
 
 #ifdef TYPE_INT64_T
@@ -238,6 +286,12 @@ Init_fiddle(void)
      * C type - int64_t
      */
     rb_define_const(mFiddle, "TYPE_INT64_T",   INT2NUM(TYPE_INT64_T));
+
+    /* Document-const: TYPE_UINT64_T
+     *
+     * C type - uint64_t
+     */
+    rb_define_const(mFiddle, "TYPE_UINT64_T",   INT2NUM(TYPE_UINT64_T));
 #endif
 
     /* Document-const: TYPE_FLOAT
@@ -422,11 +476,23 @@ Init_fiddle(void)
      */
     rb_define_const(mFiddle, "SIZEOF_CHAR",  INT2NUM(sizeof(char)));
 
+    /* Document-const: SIZEOF_UCHAR
+     *
+     * size of a unsigned char
+     */
+    rb_define_const(mFiddle, "SIZEOF_UCHAR",  INT2NUM(sizeof(unsigned char)));
+
     /* Document-const: SIZEOF_SHORT
      *
      * size of a short
      */
     rb_define_const(mFiddle, "SIZEOF_SHORT", INT2NUM(sizeof(short)));
+
+    /* Document-const: SIZEOF_USHORT
+     *
+     * size of a unsigned short
+     */
+    rb_define_const(mFiddle, "SIZEOF_USHORT", INT2NUM(sizeof(unsigned short)));
 
     /* Document-const: SIZEOF_INT
      *
@@ -434,11 +500,23 @@ Init_fiddle(void)
      */
     rb_define_const(mFiddle, "SIZEOF_INT",   INT2NUM(sizeof(int)));
 
+    /* Document-const: SIZEOF_UINT
+     *
+     * size of an unsigned int
+     */
+    rb_define_const(mFiddle, "SIZEOF_UINT",   INT2NUM(sizeof(unsigned int)));
+
     /* Document-const: SIZEOF_LONG
      *
      * size of a long
      */
     rb_define_const(mFiddle, "SIZEOF_LONG",  INT2NUM(sizeof(long)));
+
+    /* Document-const: SIZEOF_ULONG
+     *
+     * size of a unsigned long
+     */
+    rb_define_const(mFiddle, "SIZEOF_ULONG",  INT2NUM(sizeof(unsigned long)));
 
 #if HAVE_LONG_LONG
     /* Document-const: SIZEOF_LONG_LONG
@@ -446,6 +524,12 @@ Init_fiddle(void)
      * size of a long long
      */
     rb_define_const(mFiddle, "SIZEOF_LONG_LONG",  INT2NUM(sizeof(LONG_LONG)));
+
+    /* Document-const: SIZEOF_ULONG_LONG
+     *
+     * size of a unsigned long long
+     */
+    rb_define_const(mFiddle, "SIZEOF_ULONG_LONG",  INT2NUM(sizeof(unsigned LONG_LONG)));
 #endif
 
     /* Document-const: SIZEOF_INT8_T
@@ -454,11 +538,23 @@ Init_fiddle(void)
      */
     rb_define_const(mFiddle, "SIZEOF_INT8_T",  INT2NUM(sizeof(int8_t)));
 
+    /* Document-const: SIZEOF_UINT8_T
+     *
+     * size of a uint8_t
+     */
+    rb_define_const(mFiddle, "SIZEOF_UINT8_T",  INT2NUM(sizeof(uint8_t)));
+
     /* Document-const: SIZEOF_INT16_T
      *
      * size of a int16_t
      */
     rb_define_const(mFiddle, "SIZEOF_INT16_T", INT2NUM(sizeof(int16_t)));
+
+    /* Document-const: SIZEOF_UINT16_T
+     *
+     * size of a uint16_t
+     */
+    rb_define_const(mFiddle, "SIZEOF_UINT16_T", INT2NUM(sizeof(uint16_t)));
 
     /* Document-const: SIZEOF_INT32_T
      *
@@ -466,11 +562,23 @@ Init_fiddle(void)
      */
     rb_define_const(mFiddle, "SIZEOF_INT32_T", INT2NUM(sizeof(int32_t)));
 
+    /* Document-const: SIZEOF_UINT32_T
+     *
+     * size of a uint32_t
+     */
+    rb_define_const(mFiddle, "SIZEOF_UINT32_T", INT2NUM(sizeof(uint32_t)));
+
     /* Document-const: SIZEOF_INT64_T
      *
      * size of a int64_t
      */
     rb_define_const(mFiddle, "SIZEOF_INT64_T", INT2NUM(sizeof(int64_t)));
+
+    /* Document-const: SIZEOF_UINT64_T
+     *
+     * size of a uint64_t
+     */
+    rb_define_const(mFiddle, "SIZEOF_UINT64_T", INT2NUM(sizeof(uint64_t)));
 
     /* Document-const: SIZEOF_FLOAT
      *

--- a/ext/fiddle/fiddle.h
+++ b/ext/fiddle/fiddle.h
@@ -111,11 +111,16 @@
 #define TYPE_VOID  0
 #define TYPE_VOIDP 1
 #define TYPE_CHAR  2
+#define TYPE_UCHAR  -TYPE_CHAR
 #define TYPE_SHORT 3
+#define TYPE_USHORT -TYPE_SHORT
 #define TYPE_INT   4
+#define TYPE_UINT   -TYPE_INT
 #define TYPE_LONG  5
+#define TYPE_ULONG  -TYPE_LONG
 #if HAVE_LONG_LONG
 #define TYPE_LONG_LONG 6
+#define TYPE_ULONG_LONG -TYPE_LONG_LONG
 #endif
 #define TYPE_FLOAT 7
 #define TYPE_DOUBLE 8
@@ -123,11 +128,18 @@
 #define TYPE_CONST_STRING 10
 
 #define TYPE_INT8_T TYPE_CHAR
+#define TYPE_UINT8_T -TYPE_INT8_T
+
 #if SIZEOF_SHORT == 2
 # define TYPE_INT16_T TYPE_SHORT
 #elif SIZEOF_INT == 2
 # define TYPE_INT16_T TYPE_INT
 #endif
+
+#ifdef TYPE_INT16_T
+# define TYPE_UINT16_T -TYPE_INT16_T
+#endif
+
 #if SIZEOF_SHORT == 4
 # define TYPE_INT32_T TYPE_SHORT
 #elif SIZEOF_INT == 4
@@ -135,12 +147,21 @@
 #elif SIZEOF_LONG == 4
 # define TYPE_INT32_T TYPE_LONG
 #endif
+
+#ifdef TYPE_INT32_T
+#define TYPE_UINT32_T -TYPE_INT32_T
+#endif
+
 #if SIZEOF_INT == 8
 # define TYPE_INT64_T TYPE_INT
 #elif SIZEOF_LONG == 8
 # define TYPE_INT64_T TYPE_LONG
 #elif defined(TYPE_LONG_LONG)
 # define TYPE_INT64_T TYPE_LONG_LONG
+#endif
+
+#ifdef TYPE_INT64_T
+#define TYPE_UINT64_T -TYPE_INT64_T
 #endif
 
 #ifndef TYPE_SSIZE_T

--- a/lib/fiddle/cparser.rb
+++ b/lib/fiddle/cparser.rb
@@ -164,23 +164,23 @@ module Fiddle
         unless Fiddle.const_defined?(:TYPE_LONG_LONG)
           raise(RuntimeError, "unsupported type: #{ty}")
         end
-        return -TYPE_LONG_LONG
+        return TYPE_ULONG_LONG
       when /\A(?:signed\s+)?long(?:\s+int\s+)?(?:\s+\w+)?\z/
         return TYPE_LONG
       when /\Aunsigned\s+long(?:\s+int\s+)?(?:\s+\w+)?\z/
-        return -TYPE_LONG
+        return TYPE_ULONG
       when /\A(?:signed\s+)?int(?:\s+\w+)?\z/
         return TYPE_INT
       when /\A(?:unsigned\s+int|uint)(?:\s+\w+)?\z/
-        return -TYPE_INT
+        return TYPE_UINT
       when /\A(?:signed\s+)?short(?:\s+int\s+)?(?:\s+\w+)?\z/
         return TYPE_SHORT
       when /\Aunsigned\s+short(?:\s+int\s+)?(?:\s+\w+)?\z/
-        return -TYPE_SHORT
+        return TYPE_USHORT
       when /\A(?:signed\s+)?char(?:\s+\w+)?\z/
         return TYPE_CHAR
       when /\Aunsigned\s+char(?:\s+\w+)?\z/
-        return  -TYPE_CHAR
+        return  TYPE_UCHAR
       when /\Aint8_t(?:\s+\w+)?\z/
         unless Fiddle.const_defined?(:TYPE_INT8_T)
           raise(RuntimeError, "unsupported type: #{ty}")
@@ -190,7 +190,7 @@ module Fiddle
         unless Fiddle.const_defined?(:TYPE_INT8_T)
           raise(RuntimeError, "unsupported type: #{ty}")
         end
-        return -TYPE_INT8_T
+        return TYPE_UINT8_T
       when /\Aint16_t(?:\s+\w+)?\z/
         unless Fiddle.const_defined?(:TYPE_INT16_T)
           raise(RuntimeError, "unsupported type: #{ty}")
@@ -200,7 +200,7 @@ module Fiddle
         unless Fiddle.const_defined?(:TYPE_INT16_T)
           raise(RuntimeError, "unsupported type: #{ty}")
         end
-        return -TYPE_INT16_T
+        return TYPE_UINT16_T
       when /\Aint32_t(?:\s+\w+)?\z/
         unless Fiddle.const_defined?(:TYPE_INT32_T)
           raise(RuntimeError, "unsupported type: #{ty}")
@@ -210,7 +210,7 @@ module Fiddle
         unless Fiddle.const_defined?(:TYPE_INT32_T)
           raise(RuntimeError, "unsupported type: #{ty}")
         end
-        return -TYPE_INT32_T
+        return TYPE_INT32_T
       when /\Aint64_t(?:\s+\w+)?\z/
         unless Fiddle.const_defined?(:TYPE_INT64_T)
           raise(RuntimeError, "unsupported type: #{ty}")
@@ -220,7 +220,7 @@ module Fiddle
         unless Fiddle.const_defined?(:TYPE_INT64_T)
           raise(RuntimeError, "unsupported type: #{ty}")
         end
-        return -TYPE_INT64_T
+        return TYPE_UINT64_T
       when /\Afloat(?:\s+\w+)?\z/
         return TYPE_FLOAT
       when /\Adouble(?:\s+\w+)?\z/

--- a/lib/fiddle/cparser.rb
+++ b/lib/fiddle/cparser.rb
@@ -210,7 +210,7 @@ module Fiddle
         unless Fiddle.const_defined?(:TYPE_INT32_T)
           raise(RuntimeError, "unsupported type: #{ty}")
         end
-        return TYPE_INT32_T
+        return TYPE_UINT32_T
       when /\Aint64_t(?:\s+\w+)?\z/
         unless Fiddle.const_defined?(:TYPE_INT64_T)
           raise(RuntimeError, "unsupported type: #{ty}")

--- a/lib/fiddle/pack.rb
+++ b/lib/fiddle/pack.rb
@@ -11,10 +11,10 @@ module Fiddle
       TYPE_LONG  => ALIGN_LONG,
       TYPE_FLOAT => ALIGN_FLOAT,
       TYPE_DOUBLE => ALIGN_DOUBLE,
-      -TYPE_CHAR  => ALIGN_CHAR,
-      -TYPE_SHORT => ALIGN_SHORT,
-      -TYPE_INT   => ALIGN_INT,
-      -TYPE_LONG  => ALIGN_LONG,
+      TYPE_UCHAR  => ALIGN_CHAR,
+      TYPE_USHORT => ALIGN_SHORT,
+      TYPE_UINT   => ALIGN_INT,
+      TYPE_ULONG  => ALIGN_LONG,
     }
 
     PACK_MAP = {
@@ -25,10 +25,10 @@ module Fiddle
       TYPE_LONG  => "l!",
       TYPE_FLOAT => "f",
       TYPE_DOUBLE => "d",
-      -TYPE_CHAR  => "C",
-      -TYPE_SHORT => "S!",
-      -TYPE_INT   => "I!",
-      -TYPE_LONG  => "L!",
+      TYPE_UCHAR  => "C",
+      TYPE_USHORT => "S!",
+      TYPE_UINT   => "I!",
+      TYPE_ULONG  => "L!",
     }
 
     SIZE_MAP = {
@@ -39,16 +39,16 @@ module Fiddle
       TYPE_LONG  => SIZEOF_LONG,
       TYPE_FLOAT => SIZEOF_FLOAT,
       TYPE_DOUBLE => SIZEOF_DOUBLE,
-      -TYPE_CHAR  => SIZEOF_CHAR,
-      -TYPE_SHORT => SIZEOF_SHORT,
-      -TYPE_INT   => SIZEOF_INT,
-      -TYPE_LONG  => SIZEOF_LONG,
+      TYPE_UCHAR  => SIZEOF_CHAR,
+      TYPE_USHORT => SIZEOF_SHORT,
+      TYPE_UINT   => SIZEOF_INT,
+      TYPE_ULONG  => SIZEOF_LONG,
     }
     if defined?(TYPE_LONG_LONG)
-      ALIGN_MAP[TYPE_LONG_LONG] = ALIGN_MAP[-TYPE_LONG_LONG] = ALIGN_LONG_LONG
+      ALIGN_MAP[TYPE_LONG_LONG] = ALIGN_MAP[TYPE_ULONG_LONG] = ALIGN_LONG_LONG
       PACK_MAP[TYPE_LONG_LONG] = "q"
-      PACK_MAP[-TYPE_LONG_LONG] = "Q"
-      SIZE_MAP[TYPE_LONG_LONG] = SIZE_MAP[-TYPE_LONG_LONG] = SIZEOF_LONG_LONG
+      PACK_MAP[TYPE_ULONG_LONG] = "Q"
+      SIZE_MAP[TYPE_LONG_LONG] = SIZE_MAP[TYPE_ULONG_LONG] = SIZEOF_LONG_LONG
       PACK_MAP[TYPE_VOIDP] = "Q" if SIZEOF_LONG_LONG == SIZEOF_VOIDP
     end
 

--- a/test/fiddle/test_import.rb
+++ b/test/fiddle/test_import.rb
@@ -130,6 +130,8 @@ module Fiddle
         name = $1.sub(/P\z/,"*").gsub(/_(?!T\z)/, " ").downcase
         type_name = name
       end
+      type_name = "unsigned #{$1}" if type_name =~ /u(long|short|char)/
+
       define_method("test_sizeof_#{name}") do
         assert_equal(size, Fiddle::Importer.sizeof(type_name), type)
       end

--- a/test/fiddle/test_import.rb
+++ b/test/fiddle/test_import.rb
@@ -130,7 +130,7 @@ module Fiddle
         name = $1.sub(/P\z/,"*").gsub(/_(?!T\z)/, " ").downcase
         type_name = name
       end
-      type_name = "unsigned #{$1}" if type_name =~ /u(long|short|char)/
+      type_name = "unsigned #{$1}" if type_name =~ /\Au(long|short|char|int|long long)\z/
 
       define_method("test_sizeof_#{name}") do
         assert_equal(size, Fiddle::Importer.sizeof(type_name), type)

--- a/test/fiddle/test_import.rb
+++ b/test/fiddle/test_import.rb
@@ -137,6 +137,14 @@ module Fiddle
       end
     end
 
+    # Assert that the unsigned constants are equal to the "negative" signed ones
+    # for backwards compatibility
+    def test_unsigned_equals_negative_signed
+      Fiddle.constants.grep(/\ATYPE_(?!VOID|VARIADIC\z)(U.*)/) do |unsigned|
+        assert_equal -Fiddle.const_get(unsigned.to_s.sub(/U/, '')), Fiddle.const_get(unsigned)
+      end
+    end
+
     def test_unsigned_result()
       d = (2 ** 31) + 1
 


### PR DESCRIPTION
This commit adds constants for unsigned values.  Currently we can use `-` to mean "unsigned", but I think having a specific name makes Fiddle more user friendly.  This commit continues to support `-`, but introduces negative constants with "unsigned" names

I think this will help to eliminate [this code](https://github.com/ruby/ruby/blob/3a56bf0bcc66e14ffe5ec89efc32ecfceed180f4/lib/mjit/c_type.rb#L31-L38)