### PR TITLE
Move "type" constants to `Fiddle::Types`

### DIFF
--- a/ext/fiddle/fiddle.c
+++ b/ext/fiddle/fiddle.c
@@ -346,7 +346,7 @@ Init_fiddle(void)
      */
     rb_define_const(mFiddleTypes, "INTPTR_T",  INT2NUM(TYPE_INTPTR_T));
 
-    /* Document-const: Fiddle::TypesUINTPTR_T
+    /* Document-const: Fiddle::Types::UINTPTR_T
      *
      * C type - uintptr_t
      */

--- a/ext/fiddle/fiddle.c
+++ b/ext/fiddle/fiddle.c
@@ -164,191 +164,193 @@ Init_fiddle(void)
      */
     rb_eFiddleDLError = rb_define_class_under(mFiddle, "DLError", rb_eFiddleError);
 
-    /* Document-const: TYPE_VOID
+    VALUE mFiddleTypes = rb_define_module_under(mFiddle, "Types");
+
+    /* Document-const: Fiddle::Types::VOID
      *
      * C type - void
      */
-    rb_define_const(mFiddle, "TYPE_VOID",      INT2NUM(TYPE_VOID));
+    rb_define_const(mFiddleTypes, "VOID",      INT2NUM(TYPE_VOID));
 
-    /* Document-const: TYPE_VOIDP
+    /* Document-const: Fiddle::Types::VOIDP
      *
      * C type - void*
      */
-    rb_define_const(mFiddle, "TYPE_VOIDP",     INT2NUM(TYPE_VOIDP));
+    rb_define_const(mFiddleTypes, "VOIDP",     INT2NUM(TYPE_VOIDP));
 
-    /* Document-const: TYPE_CHAR
+    /* Document-const: Fiddle::Types::CHAR
      *
      * C type - char
      */
-    rb_define_const(mFiddle, "TYPE_CHAR",      INT2NUM(TYPE_CHAR));
+    rb_define_const(mFiddleTypes, "CHAR",      INT2NUM(TYPE_CHAR));
 
-    /* Document-const: TYPE_UCHAR
+    /* Document-const: Fiddle::Types::UCHAR
      *
      * C type - unsigned char
      */
-    rb_define_const(mFiddle, "TYPE_UCHAR",      INT2NUM(TYPE_UCHAR));
+    rb_define_const(mFiddleTypes, "UCHAR",      INT2NUM(TYPE_UCHAR));
 
-    /* Document-const: TYPE_SHORT
+    /* Document-const: Fiddle::Types::SHORT
      *
      * C type - short
      */
-    rb_define_const(mFiddle, "TYPE_SHORT",     INT2NUM(TYPE_SHORT));
+    rb_define_const(mFiddleTypes, "SHORT",     INT2NUM(TYPE_SHORT));
 
-    /* Document-const: TYPE_USHORT
+    /* Document-const: Fiddle::Types::USHORT
      *
      * C type - unsigned short
      */
-    rb_define_const(mFiddle, "TYPE_USHORT",     INT2NUM(TYPE_USHORT));
+    rb_define_const(mFiddleTypes, "USHORT",     INT2NUM(TYPE_USHORT));
 
-    /* Document-const: TYPE_INT
+    /* Document-const: Fiddle::Types::INT
      *
      * C type - int
      */
-    rb_define_const(mFiddle, "TYPE_INT",       INT2NUM(TYPE_INT));
+    rb_define_const(mFiddleTypes, "INT",       INT2NUM(TYPE_INT));
 
-    /* Document-const: TYPE_UINT
+    /* Document-const: Fiddle::Types::UINT
      *
      * C type - unsigned int
      */
-    rb_define_const(mFiddle, "TYPE_UINT",       INT2NUM(TYPE_UINT));
+    rb_define_const(mFiddleTypes, "UINT",       INT2NUM(TYPE_UINT));
 
-    /* Document-const: TYPE_LONG
+    /* Document-const: Fiddle::Types::LONG
      *
      * C type - long
      */
-    rb_define_const(mFiddle, "TYPE_LONG",      INT2NUM(TYPE_LONG));
+    rb_define_const(mFiddleTypes, "LONG",      INT2NUM(TYPE_LONG));
 
-    /* Document-const: TYPE_ULONG
+    /* Document-const: Fiddle::Types::ULONG
      *
      * C type - long
      */
-    rb_define_const(mFiddle, "TYPE_ULONG",      INT2NUM(TYPE_ULONG));
+    rb_define_const(mFiddleTypes, "ULONG",      INT2NUM(TYPE_ULONG));
 
 #if HAVE_LONG_LONG
-    /* Document-const: TYPE_LONG_LONG
+    /* Document-const: Fiddle::Types::LONG_LONG
      *
      * C type - long long
      */
-    rb_define_const(mFiddle, "TYPE_LONG_LONG", INT2NUM(TYPE_LONG_LONG));
+    rb_define_const(mFiddleTypes, "LONG_LONG", INT2NUM(TYPE_LONG_LONG));
 
-    /* Document-const: TYPE_ULONG_LONG
+    /* Document-const: Fiddle::Types::ULONG_LONG
      *
      * C type - long long
      */
-    rb_define_const(mFiddle, "TYPE_ULONG_LONG", INT2NUM(TYPE_ULONG_LONG));
+    rb_define_const(mFiddleTypes, "ULONG_LONG", INT2NUM(TYPE_ULONG_LONG));
 #endif
 
 #ifdef TYPE_INT8_T
-    /* Document-const: TYPE_INT8_T
+    /* Document-const: Fiddle::Types::INT8_T
      *
      * C type - int8_t
      */
-    rb_define_const(mFiddle, "TYPE_INT8_T",    INT2NUM(TYPE_INT8_T));
+    rb_define_const(mFiddleTypes, "INT8_T",    INT2NUM(TYPE_INT8_T));
 
-    /* Document-const: TYPE_UINT8_T
+    /* Document-const: Fiddle::Types::UINT8_T
      *
      * C type - uint8_t
      */
-    rb_define_const(mFiddle, "TYPE_UINT8_T",    INT2NUM(TYPE_UINT8_T));
+    rb_define_const(mFiddleTypes, "UINT8_T",    INT2NUM(TYPE_UINT8_T));
 #endif
 
 #ifdef TYPE_INT16_T
-    /* Document-const: TYPE_INT16_T
+    /* Document-const: Fiddle::Types::INT16_T
      *
      * C type - int16_t
      */
-    rb_define_const(mFiddle, "TYPE_INT16_T",   INT2NUM(TYPE_INT16_T));
+    rb_define_const(mFiddleTypes, "INT16_T",   INT2NUM(TYPE_INT16_T));
 
-    /* Document-const: TYPE_UINT16_T
+    /* Document-const: Fiddle::Types::UINT16_T
      *
      * C type - uint16_t
      */
-    rb_define_const(mFiddle, "TYPE_UINT16_T",   INT2NUM(TYPE_UINT16_T));
+    rb_define_const(mFiddleTypes, "UINT16_T",   INT2NUM(TYPE_UINT16_T));
 #endif
 
 #ifdef TYPE_INT32_T
-    /* Document-const: TYPE_INT32_T
+    /* Document-const: Fiddle::Types::INT32_T
      *
      * C type - int32_t
      */
-    rb_define_const(mFiddle, "TYPE_INT32_T",   INT2NUM(TYPE_INT32_T));
+    rb_define_const(mFiddleTypes, "INT32_T",   INT2NUM(TYPE_INT32_T));
 
-    /* Document-const: TYPE_UINT32_T
+    /* Document-const: Fiddle::Types::UINT32_T
      *
      * C type - uint32_t
      */
-    rb_define_const(mFiddle, "TYPE_UINT32_T",   INT2NUM(TYPE_UINT32_T));
+    rb_define_const(mFiddleTypes, "UINT32_T",   INT2NUM(TYPE_UINT32_T));
 #endif
 
 #ifdef TYPE_INT64_T
-    /* Document-const: TYPE_INT64_T
+    /* Document-const: Fiddle::Types::INT64_T
      *
      * C type - int64_t
      */
-    rb_define_const(mFiddle, "TYPE_INT64_T",   INT2NUM(TYPE_INT64_T));
+    rb_define_const(mFiddleTypes, "INT64_T",   INT2NUM(TYPE_INT64_T));
 
-    /* Document-const: TYPE_UINT64_T
+    /* Document-const: Fiddle::Types::UINT64_T
      *
      * C type - uint64_t
      */
-    rb_define_const(mFiddle, "TYPE_UINT64_T",   INT2NUM(TYPE_UINT64_T));
+    rb_define_const(mFiddleTypes, "UINT64_T",   INT2NUM(TYPE_UINT64_T));
 #endif
 
-    /* Document-const: TYPE_FLOAT
+    /* Document-const: Fiddle::Types::FLOAT
      *
      * C type - float
      */
-    rb_define_const(mFiddle, "TYPE_FLOAT",     INT2NUM(TYPE_FLOAT));
+    rb_define_const(mFiddleTypes, "FLOAT",     INT2NUM(TYPE_FLOAT));
 
-    /* Document-const: TYPE_DOUBLE
+    /* Document-const: Fiddle::Types::DOUBLE
      *
      * C type - double
      */
-    rb_define_const(mFiddle, "TYPE_DOUBLE",    INT2NUM(TYPE_DOUBLE));
+    rb_define_const(mFiddleTypes, "DOUBLE",    INT2NUM(TYPE_DOUBLE));
 
 #ifdef HAVE_FFI_PREP_CIF_VAR
-    /* Document-const: TYPE_VARIADIC
+    /* Document-const: Fiddle::Types::VARIADIC
      *
      * C type - ...
      */
-    rb_define_const(mFiddle, "TYPE_VARIADIC",  INT2NUM(TYPE_VARIADIC));
+    rb_define_const(mFiddleTypes, "VARIADIC",  INT2NUM(TYPE_VARIADIC));
 #endif
 
-    /* Document-const: TYPE_CONST_STRING
+    /* Document-const: Fiddle::Types::CONST_STRING
      *
      * C type - const char* ('\0' terminated const char*)
      */
-    rb_define_const(mFiddle, "TYPE_CONST_STRING",  INT2NUM(TYPE_CONST_STRING));
+    rb_define_const(mFiddleTypes, "CONST_STRING",  INT2NUM(TYPE_CONST_STRING));
 
-    /* Document-const: TYPE_SIZE_T
+    /* Document-const: Fiddle::Types::SIZE_T
      *
      * C type - size_t
      */
-    rb_define_const(mFiddle, "TYPE_SIZE_T",   INT2NUM(TYPE_SIZE_T));
+    rb_define_const(mFiddleTypes, "SIZE_T",   INT2NUM(TYPE_SIZE_T));
 
-    /* Document-const: TYPE_SSIZE_T
+    /* Document-const: Fiddle::Types::SSIZE_T
      *
      * C type - ssize_t
      */
-    rb_define_const(mFiddle, "TYPE_SSIZE_T",   INT2NUM(TYPE_SSIZE_T));
+    rb_define_const(mFiddleTypes, "SSIZE_T",   INT2NUM(TYPE_SSIZE_T));
 
-    /* Document-const: TYPE_PTRDIFF_T
+    /* Document-const: Fiddle::Types::PTRDIFF_T
      *
      * C type - ptrdiff_t
      */
-    rb_define_const(mFiddle, "TYPE_PTRDIFF_T", INT2NUM(TYPE_PTRDIFF_T));
+    rb_define_const(mFiddleTypes, "PTRDIFF_T", INT2NUM(TYPE_PTRDIFF_T));
 
-    /* Document-const: TYPE_INTPTR_T
+    /* Document-const: Fiddle::Types::INTPTR_T
      *
      * C type - intptr_t
      */
-    rb_define_const(mFiddle, "TYPE_INTPTR_T",  INT2NUM(TYPE_INTPTR_T));
+    rb_define_const(mFiddleTypes, "INTPTR_T",  INT2NUM(TYPE_INTPTR_T));
 
-    /* Document-const: TYPE_UINTPTR_T
+    /* Document-const: Fiddle::TypesUINTPTR_T
      *
      * C type - uintptr_t
      */
-    rb_define_const(mFiddle, "TYPE_UINTPTR_T",  INT2NUM(TYPE_UINTPTR_T));
+    rb_define_const(mFiddleTypes, "UINTPTR_T",  INT2NUM(TYPE_UINTPTR_T));
 
     /* Document-const: ALIGN_VOIDP
      *

--- a/lib/fiddle.rb
+++ b/lib/fiddle.rb
@@ -96,4 +96,8 @@ module Fiddle
   RTLD_GLOBAL = Handle::RTLD_GLOBAL # :nodoc:
   RTLD_LAZY   = Handle::RTLD_LAZY   # :nodoc:
   RTLD_NOW    = Handle::RTLD_NOW    # :nodoc:
+
+  Fiddle::Types.constants.each do |type|
+    const_set "TYPE_#{type}", Fiddle::Types.const_get(type)
+  end
 end

--- a/test/fiddle/test_import.rb
+++ b/test/fiddle/test_import.rb
@@ -139,6 +139,12 @@ module Fiddle
       end
     end
 
+    def test_type_constants
+      Fiddle::Types.constants.each do |const|
+        assert_equal Fiddle::Types.const_get(const), Fiddle.const_get("TYPE_#{const}")
+      end
+    end
+
     def test_unsigned_result()
       d = (2 ** 31) + 1
 


### PR DESCRIPTION
This helps to reduce repetition in code.  Instead of doing "TYPE_*" everywhere, you can do `include Fiddle::Types`, and write the type name directly.

This PR is to help reduce repetition when writing Fiddle code.  Right now we have to type `TYPE_` everywhere, and you also have to include all of `Fiddle` to access `TYPE_*` constants.  With this change, you can just include `Fiddle::Types` and it will shorten your code and also you only have to include those constants.

Here is an example before:

```ruby
require "fiddle"

module MMAP
  # All Fiddle constants included
  include Fiddle

  def self.make_function name, args, ret
    ptr = Handle::DEFAULT[name]
    func = Function.new ptr, args, ret, name: name
    define_singleton_method name, &func.to_proc
  end

  make_function "munmap", [TYPE_VOIDP, # addr
                           TYPE_SIZE_T], # len
                           TYPE_INT

  make_function "mmap", [TYPE_VOIDP,
                         TYPE_SIZE_T,
                         TYPE_INT,
                         TYPE_INT,
                         TYPE_INT,
                         TYPE_INT], TYPE_VOIDP

  make_function "mprotect", [TYPE_VOIDP, TYPE_SIZE_T, TYPE_INT], TYPE_INT
end
```

After:

```ruby
require "fiddle"

module MMAP
  # Only type names included
  include Fiddle::Types

  def self.make_function name, args, ret
    ptr = Fiddle::Handle::DEFAULT[name]
    func = Fiddle::Function.new ptr, args, ret, name: name
    define_singleton_method name, &func.to_proc
  end

  make_function "munmap", [VOIDP, # addr
                           SIZE_T], # len
                           INT

  make_function "mmap", [VOIDP, SIZE_T, INT, INT, INT, INT], VOIDP

  make_function "mprotect", [VOIDP, SIZE_T, INT], INT
end
```

We only need to import the type names, and you don't have to type `TYPE_` over and over.  I think this makes Fiddle code easier to read.