### PR TITLE
Add Qtrue, Qfalse, Qnil, and Qundef as constants

### DIFF
--- a/ext/fiddle/fiddle.c
+++ b/ext/fiddle/fiddle.c
@@ -650,6 +650,30 @@ Init_fiddle(void)
     rb_define_module_function(mFiddle, "realloc", rb_fiddle_realloc, 2);
     rb_define_module_function(mFiddle, "free", rb_fiddle_free, 1);
 
+    /* Document-const: Qtrue
+     *
+     * The value of Qtrue
+     */
+    rb_define_const(mFiddle, "Qtrue", INT2NUM(Qtrue));
+
+    /* Document-const: Qfalse
+     *
+     * The value of Qfalse
+     */
+    rb_define_const(mFiddle, "Qfalse", INT2NUM(Qfalse));
+
+    /* Document-const: Qnil
+     *
+     * The value of Qnil
+     */
+    rb_define_const(mFiddle, "Qnil", INT2NUM(Qnil));
+
+    /* Document-const: Qundef
+     *
+     * The value of Qundef
+     */
+    rb_define_const(mFiddle, "Qundef", INT2NUM(Qundef));
+
     Init_fiddle_function();
     Init_fiddle_closure();
     Init_fiddle_handle();

--- a/test/fiddle/test_fiddle.rb
+++ b/test/fiddle/test_fiddle.rb
@@ -5,6 +5,13 @@ rescue LoadError
 end
 
 class TestFiddle < Fiddle::TestCase
+  def test_nil_true_etc
+    assert_equal Fiddle::Qtrue, Fiddle.dlwrap(true)
+    assert_equal Fiddle::Qfalse, Fiddle.dlwrap(false)
+    assert_equal Fiddle::Qnil, Fiddle.dlwrap(nil)
+    assert Fiddle::Qundef
+  end
+
   def test_windows_constant
     require 'rbconfig'
     if RbConfig::CONFIG['host_os'] =~ /mswin|mingw/


### PR DESCRIPTION
It's easy to get access to `Qtrue`, `Qfalse`, and `Qnil` via Fiddle. You can just do `Fiddle.dlwrap(true)`.  But it's not possible to get access to `Qundef` from pure Ruby.

This patch adds all of these magic constants as constants on Fiddle so that we can write JIT compilers in pure Ruby.