### PR TITLE
fiddle: Use C11 _Alignof to define ALIGN_OF when possible

### DIFF
--- a/ext/fiddle/fiddle.h
+++ b/ext/fiddle/fiddle.h
@@ -199,10 +199,10 @@
 /* GCC releases before GCC 4.9 had a bug in _Alignof.  See GCC bug 52023
    <https://gcc.gnu.org/bugzilla/show_bug.cgi?id=52023>.
    clang versions < 8.0.0 have the same bug.  */
-#if (!defined __STDC_VERSION__ || __STDC_VERSION__ < 201112 \
-     || (defined __GNUC__ && __GNUC__ < 4 + (__GNUC_MINOR__ < 9) \
-         && !defined __clang__) \
-     || (defined __clang__ && __clang_major__ < 8))
+#if (!defined(__STDC_VERSION__) || __STDC_VERSION__ < 201112 \
+     || (defined(__GNUC__) && __GNUC__ < 4 + (__GNUC_MINOR__ < 9) \
+         && !defined(__clang__)) \
+     || (defined(__clang__) && __clang_major__ < 8))
 # define ALIGN_OF(type) offsetof(struct {char align_c; type align_x;}, align_x)
 #else
 # define ALIGN_OF(type) _Alignof(type)

--- a/ext/fiddle/fiddle.h
+++ b/ext/fiddle/fiddle.h
@@ -196,7 +196,17 @@
 #endif
 #define TYPE_UINTPTR_T (-TYPE_INTPTR_T)
 
-#define ALIGN_OF(type) offsetof(struct {char align_c; type align_x;}, align_x)
+/* GCC releases before GCC 4.9 had a bug in _Alignof.  See GCC bug 52023
+   <https://gcc.gnu.org/bugzilla/show_bug.cgi?id=52023>.
+   clang versions < 8.0.0 have the same bug.  */
+#if (!defined __STDC_VERSION__ || __STDC_VERSION__ < 201112 \
+     || (defined __GNUC__ && __GNUC__ < 4 + (__GNUC_MINOR__ < 9) \
+         && !defined __clang__) \
+     || (defined __clang__ && __clang_major__ < 8))
+# define ALIGN_OF(type) offsetof(struct {char align_c; type align_x;}, align_x)
+#else
+# define ALIGN_OF(type) _Alignof(type)
+#endif
 
 #define ALIGN_VOIDP  ALIGN_OF(void*)
 #define ALIGN_CHAR   ALIGN_OF(char)


### PR DESCRIPTION
WG14 N2350 made very clear that it is an UB having type definitions within "offsetof" [1]. This patch enhances the implementation of macro ALIGN_OF to use builtin "_Alignof" to avoid undefined behavior when using std=c11 or newer

clang 16+ has started to flag this [2]

Fixes build when using -std >= gnu11 and using clang16+

Older compilers gcc < 4.9 or clang < 8 has buggy _Alignof even though it may support C11, exclude those compiler versions

[1] https://www.open-std.org/jtc1/sc22/wg14/www/docs/n2350.htm [2] https://reviews.llvm.org/D133574

Signed-off-by: Khem Raj <raj.khem@gmail.com>