### PR TITLE
Remove macos-10.05 image

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
       fail-fast: false
       matrix:
         os:
-          - macos-11.0
+          - macos-11
           - macos-12
           - ubuntu-latest
           - windows-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,8 +13,8 @@ jobs:
       fail-fast: false
       matrix:
         os:
-          - macos-10.15
           - macos-11.0
+          - macos-12
           - ubuntu-latest
           - windows-latest
         ruby:


### PR DESCRIPTION
`macos-10.05` will be removed by 2023-03-31.