### PR TITLE
Mark Closure, Function and Handle as write barrier protected

### DIFF
--- a/ext/fiddle/closure.c
+++ b/ext/fiddle/closure.c
@@ -54,10 +54,13 @@ closure_memsize(const void * ptr)
 }
 
 const rb_data_type_t closure_data_type = {
-    "fiddle/closure",
-    {0, dealloc, closure_memsize,},
-    0, 0,
-    RUBY_TYPED_FREE_IMMEDIATELY,
+    .wrap_struct_name = "fiddle/closure",
+    .function = {
+        .dmark = 0,
+        .dfree = dealloc,
+        .dsize = closure_memsize
+    },
+    .flags = RUBY_TYPED_FREE_IMMEDIATELY | RUBY_TYPED_WB_PROTECTED,
 };
 
 struct callback_args {

--- a/ext/fiddle/function.c
+++ b/ext/fiddle/function.c
@@ -53,8 +53,13 @@ function_memsize(const void *p)
 }
 
 const rb_data_type_t function_data_type = {
-    "fiddle/function",
-    {0, deallocate, function_memsize,},
+    .wrap_struct_name = "fiddle/function",
+    .function = {
+        .dmark = 0,
+        .dfree = deallocate,
+        .dsize = function_memsize
+    },
+    .flags = RUBY_TYPED_FREE_IMMEDIATELY | RUBY_TYPED_WB_PROTECTED,
 };
 
 static VALUE

--- a/ext/fiddle/handle.c
+++ b/ext/fiddle/handle.c
@@ -50,8 +50,13 @@ fiddle_handle_memsize(const void *ptr)
 }
 
 static const rb_data_type_t fiddle_handle_data_type = {
-    "fiddle/handle",
-    {0, fiddle_handle_free, fiddle_handle_memsize,},
+    .wrap_struct_name = "fiddle/handle",
+    .function = {
+        .dmark = 0,
+        .dfree = fiddle_handle_free,
+        .dsize = fiddle_handle_memsize
+    },
+    .flags = RUBY_TYPED_WB_PROTECTED,
 };
 
 /*


### PR DESCRIPTION
They don't have a mark function, so they don't need any change.