### PR TITLE
Suppress -Wundef warnings on arm64 macOS and Windows

### DIFF
--- a/ext/fiddle/extconf.rb
+++ b/ext/fiddle/extconf.rb
@@ -63,6 +63,11 @@ unless bundle
   end
   if have_ffi_header && (have_library('ffi') || have_library('libffi'))
     have_libffi = true
+    checking_for("undefined FFI_GO_CLOSURES is used") do
+      if egrep_cpp(/warning: 'FFI_GO_CLOSURES' is not defined/, cpp_include(ffi_header), "2>&1")
+        $defs.push('-DFFI_GO_CLOSURES=0')
+      end
+    end
   end
 end
 


### PR DESCRIPTION
```
In file included from ../../../../ext/fiddle/fiddle.h:46:
/opt/local/include/ffi.h:477:5: warning: 'FFI_GO_CLOSURES' is not defined, evaluates to 0 [-Wundef]
    ^
```

c.f. https://github.com/libffi/libffi/pull/796