### PR TITLE
Use ruby/actions workflow for ruby versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,7 +5,15 @@ on:
   - pull_request
 
 jobs:
+  ruby-versions:
+    uses: ruby/actions/.github/workflows/ruby_versions.yml@master
+    with:
+      engine: cruby
+      min_version: 2.5
+      versions: "[debug]"
+
   host:
+    needs: ruby-versions
     name: >-
       ${{ matrix.os }} ${{ matrix.ruby }}
     runs-on: ${{ matrix.os }}
@@ -17,14 +25,7 @@ jobs:
           - macos-12
           - ubuntu-latest
           - windows-latest
-        ruby:
-          - '2.5'
-          - '2.6'
-          - '2.7'
-          - '3.0'
-          - '3.1'
-          - '3.2'
-          - debug
+        ruby: ${{ fromJson(needs.ruby-versions.outputs.versions) }}
         include:
           - { os: windows-latest , ruby: mingw }
           - { os: windows-latest , ruby: mswin }

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,8 @@ jobs:
     with:
       engine: cruby
       min_version: 2.5
-      versions: "[debug]"
+      versions:
+        - debug
 
   host:
     needs: ruby-versions

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,8 +10,7 @@ jobs:
     with:
       engine: cruby
       min_version: 2.5
-      versions:
-        - debug
+      versions: '["debug"]'
 
   host:
     needs: ruby-versions

--- a/.github/workflows/libffi.yml
+++ b/.github/workflows/libffi.yml
@@ -3,12 +3,19 @@ name: libffi
 on: [push, pull_request]
 
 jobs:
+  ruby-versions:
+    uses: ruby/actions/.github/workflows/ruby_versions.yml@master
+    with:
+      engine: cruby
+      min_version: 2.5
+
   build:
+    needs: ruby-versions
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
-        ruby: [ head, 3.1, "3.0", 2.7, 2.6, 2.5 ]
+        ruby: ${{ fromJson(needs.ruby-versions.outputs.versions) }}
         libffi: [3.2.1]
         libffi-prefix: [/tmp/local, '']
 


### PR DESCRIPTION
this PR has been changed to use the [ruby/actions](https://github.com/ruby/actions/blob/master/.github/workflows/ruby_versions.yml) workflow for ruby versions.