### PR TITLE
Use macos-arm-oss instead of macos-11

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,6 +29,7 @@ jobs:
           - { os: windows-latest , ruby: mingw }
           - { os: windows-latest , ruby: mswin }
         exclude:
+          - { os: macos-arm-oss  , ruby: '2.5' }
           - { os: windows-latest , ruby: '3.0' }
           - { os: windows-latest , ruby: debug }
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -81,7 +81,7 @@ jobs:
       fail-fast: false
       matrix:
         service:
-          - fedora-33
+          - fedora-latest
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,8 +13,8 @@ jobs:
       fail-fast: false
       matrix:
         os:
-          - macos-11
           - macos-12
+          - macos-arm-oss
           - ubuntu-latest
           - windows-latest
         ruby:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,10 +1,10 @@
 version: "3.5"
 
 services:
-  fedora-33:
+  fedora-latest:
     build:
       context: .
-      dockerfile: dockerfiles/fedora-33.dockerfile
+      dockerfile: dockerfiles/fedora-latest.dockerfile
     volumes:
       - .:/source:delegated
     command:

--- a/dockerfiles/fedora-latest.dockerfile
+++ b/dockerfiles/fedora-latest.dockerfile
@@ -1,4 +1,4 @@
-FROM fedora:33
+FROM fedora:latest
 
 RUN \
   dnf install -y \


### PR DESCRIPTION
macos-11 (Big Sur) is EOL today. I removed it and add `macos-arm-oss` instead of `macos-11`. `macos-arm-oss` is `macos-13` with Apple Silicon architecture. We can cover with them for real world usage.