### PR TITLE
Remove Vim commands

### DIFF
--- a/ext/fiddle/closure.c
+++ b/ext/fiddle/closure.c
@@ -455,4 +455,3 @@ Init_fiddle_closure(void)
      */
     rb_define_method(cFiddleClosure, "freed?", closure_freed_p, 0);
 }
-/* vim: set noet sw=4 sts=4 */

--- a/ext/fiddle/conversions.c
+++ b/ext/fiddle/conversions.c
@@ -379,5 +379,3 @@ generic_to_value(VALUE rettype, fiddle_generic retval)
 {
     return rb_fiddle_generic_to_value(rettype, retval);
 }
-
-/* vim: set noet sw=4 sts=4 */

--- a/ext/fiddle/fiddle.c
+++ b/ext/fiddle/fiddle.c
@@ -709,4 +709,3 @@ Init_fiddle(void)
     Init_fiddle_memory_view();
 #endif
 }
-/* vim: set noet sws=4 sw=4: */

--- a/ext/fiddle/fiddle.h
+++ b/ext/fiddle/fiddle.h
@@ -237,4 +237,3 @@ typedef void (*rb_fiddle_freefunc_t)(void*);
 VALUE rb_fiddle_ptr_new_wrap(void *ptr, long size, rb_fiddle_freefunc_t func, VALUE wrap0, VALUE wrap1);
 
 #endif
-/* vim: set noet sws=4 sw=4: */

--- a/ext/fiddle/function.c
+++ b/ext/fiddle/function.c
@@ -493,4 +493,3 @@ Init_fiddle_function(void)
      */
     rb_define_method(cFiddleFunction, "initialize", initialize, -1);
 }
-/* vim: set noet sws=4 sw=4: */

--- a/ext/fiddle/handle.c
+++ b/ext/fiddle/handle.c
@@ -587,5 +587,3 @@ Init_fiddle_handle(void)
     rb_define_method(rb_cHandle, "enable_close", rb_fiddle_handle_enable_close, 0);
     rb_define_method(rb_cHandle, "close_enabled?", rb_fiddle_handle_close_enabled_p, 0);
 }
-
-/* vim: set noet sws=4 sw=4: */


### PR DESCRIPTION
Some of these commands just don't work (for example `sws` is not a Vim setting). I think we should just remove these.