### PR TITLE
Skip native extension building on non-CRuby

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,6 +73,31 @@ jobs:
           cd tmp
           ruby test/run.rb
 
+  # Don't run tests on TruffleRuby and JRuby because tests don't pass on them yet.
+  # So check only gem installing.
+  install:
+    name: >-
+      Install ${{ matrix.ruby }}
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        ruby:
+          - truffleruby
+          - jruby
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: ${{ matrix.ruby }}
+          bundler-cache: true
+
+      - run: rake install
+
+      - run: ruby -e 'require "fiddle"'
+
   docker:
     name: >-
       ${{ matrix.service }}

--- a/Rakefile
+++ b/Rakefile
@@ -17,8 +17,12 @@ namespace :version do
   end
 end
 
-require 'rake/extensiontask'
-Rake::ExtensionTask.new("fiddle")
-Rake::ExtensionTask.new("-test-/memory_view")
+if RUBY_ENGINE == 'ruby'
+  require 'rake/extensiontask'
+  Rake::ExtensionTask.new("fiddle")
+  Rake::ExtensionTask.new("-test-/memory_view")
+else
+  task :compile
+end
 
 task :default => [:compile, :test]

--- a/ext/fiddle/extconf.rb
+++ b/ext/fiddle/extconf.rb
@@ -1,6 +1,11 @@
 # frozen_string_literal: true
 require 'mkmf'
 
+if RUBY_ENGINE != 'ruby'
+  File.write('Makefile', dummy_makefile("").join)
+  return
+end
+
 # :stopdoc:
 
 def gcc?

--- a/lib/fiddle.rb
+++ b/lib/fiddle.rb
@@ -1,6 +1,13 @@
 # frozen_string_literal: true
 
-require 'fiddle.so'
+if RUBY_ENGINE == "ruby"
+  require 'fiddle.so'
+else
+  $LOAD_PATH.delete(__dir__)
+  require 'fiddle' # load from stdlib
+  return
+end
+
 require 'fiddle/closure'
 require 'fiddle/function'
 require 'fiddle/version'

--- a/test/run.rb
+++ b/test/run.rb
@@ -2,7 +2,7 @@
 
 $VERBOSE = true
 
-source_dir = "#{__dir__}/.."
+source_dir = File.dirname(__dir__)
 $LOAD_PATH.unshift("#{source_dir}/test")
 $LOAD_PATH.unshift("#{source_dir}/lib")
 


### PR DESCRIPTION
Given https://bugs.ruby-lang.org/issues/20309 fiddle will become a bundled gem in Ruby 3.5+.

As a result people will add fiddle to their Gemfile where they previously wouldn't (and so there was no issue).
Unfortunately this leads to failure for example on https://github.com/ffi/ffi/pull/1119:
* https://github.com/ffi/ffi/actions/runs/10881406447/job/30190278321?pr=1119 JRuby fails when trying to build the C extension
* TruffleRuby segfaults, probably because the fiddle C extension does something unexpected, and it's completely untested on TruffleRuby. It seems better to use the TruffleRuby Fiddle backend anyway for performance, as it avoids basically going twice through libffi (one used for the C extension API and the one used by Fiddle).

The fiddle gem (in this repo) currently only works on CRuby.
So the best solution for now is to just use `fiddle` from stdlib on non-CRuby. That's properly tested and working.

Later it might be possible to upstream the Fiddle backends of JRuby / TruffleRuby in this repo.
But that is a much larger undertaking and we need to fix the failure when people have `gem "fiddle"` in their Gemfile or through a gem's dependencies.

Close #145