### PR TITLE
Cast via `VALUE` function pointer between object pointer

### DIFF
--- a/ext/fiddle/function.c
+++ b/ext/fiddle/function.c
@@ -371,7 +371,7 @@ function_call(int argc, VALUE argv[], VALUE self)
         args.values[i_call] = (void *)&generic_args[i_call];
     }
     args.values[i_call] = NULL;
-    args.fn = (void(*)(void))NUM2PTR(cfunc);
+    args.fn = (void(*)(void))(VALUE)NUM2PTR(cfunc);
 
     if (RTEST(need_gvl)) {
         ffi_call(args.cif, args.fn, &(args.retval), args.values);

--- a/ext/fiddle/pointer.c
+++ b/ext/fiddle/pointer.c
@@ -570,7 +570,7 @@ rb_fiddle_ptr_inspect(VALUE self)
 
     TypedData_Get_Struct(self, struct ptr_data, &fiddle_ptr_data_type, data);
     return rb_sprintf("#<%"PRIsVALUE":%p ptr=%p size=%ld free=%p>",
-		      RB_OBJ_CLASSNAME(self), (void *)data, data->ptr, data->size, (void *)data->free);
+		      RB_OBJ_CLASSNAME(self), (void *)data, data->ptr, data->size, (void *)(VALUE)data->free);
 }
 
 /*


### PR DESCRIPTION
With gcc 13 and -pedantic:

```
../../../src/ext/fiddle/function.c: In function ‘function_call’:
../../../src/ext/fiddle/function.c:374:15: error: ISO C forbids conversion of object pointer to function pointer type [-Wpedantic]
  374 |     args.fn = (void(*)(void))NUM2PTR(cfunc);
      |               ^
../../../src/ext/fiddle/pointer.c: In function ‘rb_fiddle_ptr_inspect’:
../../../src/ext/fiddle/pointer.c:573:84: error: ISO C forbids conversion of function pointer to object pointer type [-Wpedantic]
  573 |                       RB_OBJ_CLASSNAME(self), (void *)data, data->ptr, data->size, (void *)data->free);
      |                                                                                    ^
```