### PR TITLE
Only print Fiddle::VERSION when flag is true

### DIFF
--- a/test/fiddle/helper.rb
+++ b/test/fiddle/helper.rb
@@ -4,7 +4,7 @@ require 'rbconfig/sizeof'
 require 'test/unit'
 require 'fiddle'
 
-puts("Fiddle::VERSION: #{Fiddle::VERSION}")
+puts("Fiddle::VERSION: #{Fiddle::VERSION}") if $VERBOSE
 
 # FIXME: this is stolen from DL and needs to be refactored.
 


### PR DESCRIPTION
The test of current HEAD revision occurred `unknown command` on `ruby/ruby` repo.

```
$ make test-all -j TESTS="fiddle -j12" MSPECOPT="-j"
(snip)

# Running tests:

unknown command: "Fiddle::VERSION: 1.1.3.dev"8681=test_fiddle 58682=test_pack 58683=test_handle 58684=test_import 58685=test_c_union_entity 58686:waiting 58687=test_pinne
unknown command: "Fiddle::VERSION: 1.1.3.dev"8681=test_fiddle 58682=test_pack 58683=test_handle 58684=test_import 58685=test_c_union_entity 58686=test_cparser 58687=test_
unknown command: "Fiddle::VERSION: 1.1.3.dev"8681=test_fiddle 58682=test_pack 58683=test_handle 58684=test_import 58685=test_c_union_entity 58686=test_cparser 58687=test_
unknown command: "Fiddle::VERSION: 1.1.3.dev"8681=test_fiddle 58682=test_memory_view 58683=test_handle 58684=test_import 58685=test_c_union_entity 58686=test_cparser 5868
unknown command: "Fiddle::VERSION: 1.1.3.dev"8681=test_closure 58682=test_memory_view 58683=test_handle 58684=test_import 58685=test_c_union_entity 58686=test_cparser 586
unknown command: "Fiddle::VERSION: 1.1.3.dev"
unknown command: "Fiddle::VERSION: 1.1.3.dev"
unknown command: "Fiddle::VERSION: 1.1.3.dev"8681=test_closure 58682=test_memory_view 58683=test_handle 58684=test_import 58685=test_c_struct_builder 58686=test_cparser 5
unknown command: "Fiddle::VERSION: 1.1.3.dev"8681=test_closure 58682=test_memory_view 58683=test_handle 58684=test_import 58685=test_c_struct_builder 58686=test_cparser 5
unknown command: "Fiddle::VERSION: 1.1.3.dev"8681=test_closure 58682=test_memory_view 58683=test_handle 58684=test_import 58685=test_c_struct_builder 58686=test_cparser 5
Finished tests in 1.136194s, 194.5090 tests/s, 929.4187 assertions/s.
221 tests, 1056 assertions, 0 failures, 0 errors, 4 skips
```

I only show fiddle version in this repository with `$VERSBOSE` flag.