### PR TITLE
Don't use mkmf to generate dummy Makefile

### DIFF
--- a/ext/fiddle/extconf.rb
+++ b/ext/fiddle/extconf.rb
@@ -1,10 +1,18 @@
 # frozen_string_literal: true
-require 'mkmf'
+
+require "rbconfig"
 
 unless RUBY_ENGINE == "ruby"
-  File.write('Makefile', dummy_makefile("").join)
+  File.write('Makefile', <<-MAKEFILE)
+all install clean:
+	#{RbConfig::CONFIG["NULLCMD"]}
+
+.PHONY: all install clean
+  MAKEFILE
   return
 end
+
+require 'mkmf'
 
 # :stopdoc:
 


### PR DESCRIPTION
GitHub: fix GH-153

mkmf requires fileutils. JRuby doesn't like it.