### PR TITLE
Fix Fiddle::Handle.new for a missing library in the FFI backend

### DIFF
--- a/lib/fiddle/ffi_backend.rb
+++ b/lib/fiddle/ffi_backend.rb
@@ -475,8 +475,11 @@ module Fiddle
     RTLD_NOW = FFI::DynamicLibrary::RTLD_NOW
 
     def initialize(libname = nil, flags = RTLD_LAZY | RTLD_GLOBAL)
-      @lib = FFI::DynamicLibrary.open(libname, flags) rescue LoadError
-      raise DLError.new("Could not open #{libname}") unless @lib
+      begin
+        @lib = FFI::DynamicLibrary.open(libname, flags)
+      rescue LoadError, RuntimeError # LoadError for JRuby, RuntimeError for TruffleRuby
+        raise DLError, "Could not open #{libname}"
+      end
 
       @open = true
 

--- a/test/fiddle/test_handle.rb
+++ b/test/fiddle/test_handle.rb
@@ -8,6 +8,15 @@ module Fiddle
   class TestHandle < TestCase
     include Fiddle
 
+    def test_library_unavailable
+      assert_raise(DLError) do
+        Fiddle::Handle.new("does-not-exist-library")
+      end
+      assert_raise(DLError) do
+        Fiddle::Handle.new("/does/not/exist/library.#{RbConfig::CONFIG['SOEXT']}")
+      end
+    end
+
     def test_to_i
       if ffi_backend?
         omit("Fiddle::Handle#to_i is unavailable with FFI backend")


### PR DESCRIPTION
* From https://github.com/ruby/reline/issues/766#issuecomment-2422135968

cc @headius 