### PR TITLE
Suppress -Wundef warnings

### DIFF
--- a/ext/fiddle/extconf.rb
+++ b/ext/fiddle/extconf.rb
@@ -68,11 +68,6 @@ unless bundle
   end
   if have_ffi_header && (have_library('ffi') || have_library('libffi'))
     have_libffi = true
-    checking_for("undefined FFI_GO_CLOSURES is used") do
-      if egrep_cpp(/warning: \WFFI_GO_CLOSURES\W is not defined/, cpp_include(ffi_header), "2>&1")
-        $defs.push('-DFFI_GO_CLOSURES=0')
-      end
-    end
   end
 end
 

--- a/ext/fiddle/extconf.rb
+++ b/ext/fiddle/extconf.rb
@@ -69,7 +69,7 @@ unless bundle
   if have_ffi_header && (have_library('ffi') || have_library('libffi'))
     have_libffi = true
     checking_for("undefined FFI_GO_CLOSURES is used") do
-      if egrep_cpp(/warning: 'FFI_GO_CLOSURES' is not defined/, cpp_include(ffi_header), "2>&1")
+      if egrep_cpp(/warning: \WFFI_GO_CLOSURES\W is not defined/, cpp_include(ffi_header), "2>&1")
         $defs.push('-DFFI_GO_CLOSURES=0')
       end
     end

--- a/ext/fiddle/fiddle.h
+++ b/ext/fiddle/fiddle.h
@@ -40,6 +40,7 @@
 # endif
 #endif
 
+#define FFI_GO_CLOSURES 0 /* fiddle does not use go closures */
 #ifdef USE_HEADER_HACKS
 #include <ffi/ffi.h>
 #else


### PR DESCRIPTION
The GCC warning puts undefined macro names in double quotes while clang puts them in single quotes.