### PR TITLE
Fix test_dlopen_linker_script_input_linux being omitted on Fedora 40 aarch64

### DIFF
--- a/test/fiddle/test_fiddle.rb
+++ b/test/fiddle/test_fiddle.rb
@@ -27,7 +27,7 @@ class TestFiddle < Fiddle::TestCase
 
   def test_dlopen_linker_script_input_linux
     omit("This is only for Linux") unless RUBY_PLATFORM.match?("linux")
-    if Dir.glob("/usr/lib/*/libncurses.so").empty?
+    if Dir.glob("/usr/lib{64}/**/libncurses.so").empty?
       omit("libncurses.so is needed")
     end
     if ffi_backend?


### PR DESCRIPTION
I found working on Fedora 40 on aarch64 that  `test_dlopen_linker_script_input_linux` was omitted due to not finding libncurses.so, since it is in /usr/lib64. This PR makes the glob a little more portable.