### PR TITLE
ffi_backend: convert numeric function args to pointers

### DIFF
--- a/lib/fiddle/ffi_backend.rb
+++ b/lib/fiddle/ffi_backend.rb
@@ -159,12 +159,14 @@ module Fiddle
           args[i] = Fiddle::FFIBackend.to_ffi_type(args[i])
         end
       else
-        args.map! do |arg|
+        args.map!.with_index do |arg, i|
           if arg.respond_to?(:to_ptr)
             begin
               arg = arg.to_ptr
             end until arg.is_a?(FFI::Pointer) || !arg.respond_to?(:to_ptr)
             arg
+          elsif arg.is_a?(Integer) && @args[i] == Types::VOIDP
+            FFI::Pointer.new(arg)
           else
             arg
           end

--- a/lib/fiddle/ffi_backend.rb
+++ b/lib/fiddle/ffi_backend.rb
@@ -160,7 +160,7 @@ module Fiddle
         end
       else
         @args.each_with_index do |arg_type, i|
-          if @args[i] == Types::VOIDP
+          if arg_type == Types::VOIDP
             src = args[i]
             next if src.nil? ||
               src.is_a?(String) ||

--- a/lib/fiddle/ffi_backend.rb
+++ b/lib/fiddle/ffi_backend.rb
@@ -309,6 +309,8 @@ module Fiddle
               end
             elsif addr.is_a?(IO)
               raise NotImplementedError, "IO ptr isn't supported"
+            else
+              FFI::Pointer.new(Integer(addr))
             end
 
       @size = size ? size : ptr.size

--- a/lib/fiddle/ffi_backend.rb
+++ b/lib/fiddle/ffi_backend.rb
@@ -159,13 +159,13 @@ module Fiddle
           args[i] = Fiddle::FFIBackend.to_ffi_type(args[i])
         end
       else
-        args.zip(@args).each do |arg, type|
+        args.map!.with_index do |arg, i|
           if arg.respond_to?(:to_ptr)
             begin
               arg = arg.to_ptr
             end until arg.is_a?(FFI::Pointer) || !arg.respond_to?(:to_ptr)
             arg
-          elsif arg.is_a?(Integer) && type == Types::VOIDP
+          elsif @args[i] == Types::VOIDP && arg.is_a?(Integer)
             FFI::Pointer.new(arg)
           else
             arg

--- a/lib/fiddle/ffi_backend.rb
+++ b/lib/fiddle/ffi_backend.rb
@@ -162,7 +162,10 @@ module Fiddle
         @args.each_with_index do |arg_type, i|
           if @args[i] == Types::VOIDP
             src = args[i]
-            next if src.nil? || src.is_a?(String) || src.is_a?(FFI::Pointer)
+            next if src.nil? ||
+              src.is_a?(String) ||
+              src.is_a?(FFI::AbstractMemory) ||
+              src.is_a?(FFI::Struct)
 
             args[i] = Pointer[src]
           end

--- a/lib/fiddle/ffi_backend.rb
+++ b/lib/fiddle/ffi_backend.rb
@@ -159,16 +159,12 @@ module Fiddle
           args[i] = Fiddle::FFIBackend.to_ffi_type(args[i])
         end
       else
-        args.map!.with_index do |arg, i|
-          if arg.respond_to?(:to_ptr)
-            begin
-              arg = arg.to_ptr
-            end until arg.is_a?(FFI::Pointer) || !arg.respond_to?(:to_ptr)
-            arg
-          elsif @args[i] == Types::VOIDP && arg.is_a?(Integer)
-            FFI::Pointer.new(arg)
-          else
-            arg
+        @args.each_with_index do |arg_type, i|
+          if @args[i] == Types::VOIDP
+            src = args[i]
+            next if src.nil? || src.is_a?(String) || src.is_a?(FFI::Pointer)
+
+            args[i] = Pointer[src]
           end
         end
       end

--- a/lib/fiddle/ffi_backend.rb
+++ b/lib/fiddle/ffi_backend.rb
@@ -160,15 +160,15 @@ module Fiddle
         end
       else
         @args.each_with_index do |arg_type, i|
-          if arg_type == Types::VOIDP
-            src = args[i]
-            next if src.nil? ||
-              src.is_a?(String) ||
-              src.is_a?(FFI::AbstractMemory) ||
-              src.is_a?(FFI::Struct)
+          next unless arg_type == Types::VOIDP
 
-            args[i] = Pointer[src]
-          end
+          src = args[i]
+          next if src.nil?
+          next if src.is_a?(String)
+          next if src.is_a?(FFI::AbstractMemory)
+          next if src.is_a?(FFI::Struct)
+
+          args[i] = Pointer[src]
         end
       end
       result = @function.call(*args, &block)

--- a/lib/fiddle/ffi_backend.rb
+++ b/lib/fiddle/ffi_backend.rb
@@ -159,13 +159,13 @@ module Fiddle
           args[i] = Fiddle::FFIBackend.to_ffi_type(args[i])
         end
       else
-        args.map!.with_index do |arg, i|
+        args.zip(@args).each do |arg, type|
           if arg.respond_to?(:to_ptr)
             begin
               arg = arg.to_ptr
             end until arg.is_a?(FFI::Pointer) || !arg.respond_to?(:to_ptr)
             arg
-          elsif arg.is_a?(Integer) && @args[i] == Types::VOIDP
+          elsif arg.is_a?(Integer) && type == Types::VOIDP
             FFI::Pointer.new(arg)
           else
             arg

--- a/test/fiddle/test_function.rb
+++ b/test/fiddle/test_function.rb
@@ -101,9 +101,10 @@ module Fiddle
     def test_integer_pointer_conversion
       func = Function.new(@libc['memcpy'], [TYPE_VOIDP, TYPE_VOIDP, TYPE_SIZE_T], TYPE_VOIDP)
       str = 'hello'
-      dst = Pointer.malloc(str.bytesize, Fiddle::RUBY_FREE)
-      func.call(dst.to_i, str, dst.size)
-      assert_equal str, dst.to_str
+      Pointer.malloc(str.bytesize, Fiddle::RUBY_FREE) do |dst|
+        func.call(dst.to_i, str, dst.size)
+        assert_equal(str, dst.to_str)
+      end
     end
 
     def test_argument_count

--- a/test/fiddle/test_function.rb
+++ b/test/fiddle/test_function.rb
@@ -98,6 +98,14 @@ module Fiddle
       assert_in_delta 1.0, func.call(90 * Math::PI / 180), 0.0001
     end
 
+    def test_integer_pointer_conversion
+      func = Function.new(@libc['memcpy'], [TYPE_VOIDP, TYPE_VOIDP, TYPE_SIZE_T], TYPE_VOIDP)
+      str = 'hello'
+      dst = Pointer.malloc(str.bytesize, Fiddle::RUBY_FREE)
+      func.call(dst.to_i, str, dst.size)
+      assert_equal str, dst.to_str
+    end
+
     def test_argument_count
       closure_class = Class.new(Closure) do
         def call one

--- a/test/fiddle/test_pointer.rb
+++ b/test/fiddle/test_pointer.rb
@@ -161,9 +161,14 @@ module Fiddle
       end
     end
 
-    def test_to_ptr_with_num
+    def test_to_ptr_with_int
       ptr = Pointer.new 0
       assert_equal ptr, Pointer[0]
+    end
+
+    def test_to_ptr_with_num
+      ptr = Pointer.new 0
+      assert_equal ptr, Pointer[0.0]
     end
 
     def test_equals

--- a/test/fiddle/test_pointer.rb
+++ b/test/fiddle/test_pointer.rb
@@ -166,9 +166,10 @@ module Fiddle
       assert_equal ptr, Pointer[0]
     end
 
-    def test_to_ptr_with_num
+    MimicInteger = Struct.new(:to_int)
+    def test_to_ptr_with_to_int
       ptr = Pointer.new 0
-      assert_equal ptr, Pointer[0.0]
+      assert_equal ptr, Pointer[MimicInteger.new(0)]
     end
 
     def test_equals


### PR DESCRIPTION
This allows for passing integers as pointer arguments to functions when using the FFI backend. This is a workaround until we can get JRuby's FFI implementation to allow for it directly (see also https://github.com/jruby/jruby/pull/8423)