### PR TITLE
add regex for bool parsing & test struct w/ bool parsing

### DIFF
--- a/lib/fiddle/cparser.rb
+++ b/lib/fiddle/cparser.rb
@@ -247,7 +247,7 @@ module Fiddle
         return TYPE_INTPTR_T
       when /\Auintptr_t(?:\s+\w+)?\z/
         return TYPE_UINTPTR_T
-      when "bool"
+      when /\Abool(?:\s+\w+)?\z/
         return TYPE_BOOL
       when /\*/, /\[[\s\d]*\]/
         return TYPE_VOIDP

--- a/test/fiddle/test_cparser.rb
+++ b/test/fiddle/test_cparser.rb
@@ -277,6 +277,10 @@ module Fiddle
       assert_equal [[TYPE_INT,TYPE_VOIDP,TYPE_VOIDP], ['x', 'cb', 'name']], parse_struct_signature('int x; void (*cb)(); const char* name')
     end
 
+    def test_struct_bool
+      assert_equal [[TYPE_INT, TYPE_BOOL], ['x', 'toggle']], parse_struct_signature('int x; bool toggle')
+    end
+
     def test_struct_undefined
       assert_raise(DLError) { parse_struct_signature(['int i', 'DWORD cb']) }
     end

--- a/test/fiddle/test_cparser.rb
+++ b/test/fiddle/test_cparser.rb
@@ -278,7 +278,8 @@ module Fiddle
     end
 
     def test_struct_bool
-      assert_equal [[TYPE_INT, TYPE_BOOL], ['x', 'toggle']], parse_struct_signature('int x; bool toggle')
+      assert_equal([[TYPE_INT, TYPE_BOOL], ['x', 'toggle']],
+                   parse_struct_signature('int x; bool toggle'))
     end
 
     def test_struct_undefined


### PR DESCRIPTION
GitHub: fix GH-168

Struct parsing invokes "parse_ctype" on the whole member signature, which fails if member type is "bool" due to plain string matching for it. This change updates "bool" type matching to a regexp, so TYPE_BOOL is correctly parsed for a whole signature like "bool toggle" as well as just "bool".