### PR TITLE
Make `Fiddle::Pointer#to_s` with JRuby consistent with CRuby

### DIFF
--- a/lib/fiddle/ffi_backend.rb
+++ b/lib/fiddle/ffi_backend.rb
@@ -408,10 +408,9 @@ module Fiddle
     end
     alias to_int to_i
 
-    # without \0
     def to_s(len = nil)
       if len
-        ffi_ptr.get_string(0, len)
+        ffi_ptr.read_string(len)
       else
         ffi_ptr.get_string(0)
       end

--- a/test/fiddle/test_pointer.rb
+++ b/test/fiddle/test_pointer.rb
@@ -92,6 +92,7 @@ module Fiddle
 
       ptr[5] = 0
       assert_equal 'hello', ptr.to_s
+      assert_equal "hello\0", ptr.to_s(6)
     end
 
     def test_minus


### PR DESCRIPTION
Hi, this PR makes the behavior of `Fiddle::Pointer#to_s` consistent between CRuby and JRuby.

```ruby
ptr = Fiddle::Pointer.malloc(4)
p ptr.to_s(4)
```

currently outputs `"\x00\x00\x00\x00"` with CRuby and `""` with JRuby.