### PR TITLE
Improve `Fiddle::Pointer#inspect` for FFI backend

### DIFF
--- a/lib/fiddle/ffi_backend.rb
+++ b/lib/fiddle/ffi_backend.rb
@@ -433,11 +433,16 @@ module Fiddle
     end
 
     def inspect
-      inspect_ptr = lambda do |ptr|
-        addr = ptr.to_i
-        addr == 0 ? "0x#{"0"*(SIZEOF_VOIDP * 2)}" : sprintf("%#0#{SIZEOF_VOIDP * 2 + 2}x", addr)
-      end
-      "#<#{self.class.name} ptr=#{inspect_ptr.(self)} size=#{@size} free=#{inspect_ptr.(@free)}>"
+      # SIZEOF_VOIDP * 2 == Math.log(2 ** (SIZEOF_VOIDP * 8), 16)
+      pointer_inspect_width = SIZEOF_VOIDP * 2
+      "#<%s ptr=0x%0.*x size=%d free=0x%0.*x>" % [
+        self.class.name,
+        pointer_inspect_width,
+        to_i,
+        size,
+        pointer_inspect_width,
+        @free || 0,
+      ]
     end
 
     def +(delta)

--- a/lib/fiddle/ffi_backend.rb
+++ b/lib/fiddle/ffi_backend.rb
@@ -433,7 +433,11 @@ module Fiddle
     end
 
     def inspect
-      "#<#{self.class.name} ptr=#{to_i.to_s(16)} size=#{@size} free=#{@free.inspect}>"
+      inspect_ptr = lambda do |ptr|
+        addr = ptr.to_i
+        addr == 0 ? "0x#{"0"*(SIZEOF_VOIDP * 2)}" : sprintf("%#0#{SIZEOF_VOIDP * 2 + 2}x", addr)
+      end
+      "#<#{self.class.name} ptr=#{inspect_ptr.(self)} size=#{@size} free=#{inspect_ptr.(@free)}>"
     end
 
     def +(delta)

--- a/test/fiddle/test_pointer.rb
+++ b/test/fiddle/test_pointer.rb
@@ -110,10 +110,6 @@ module Fiddle
     end
 
     def test_inspect
-      if ffi_backend?
-        omit("Fiddle::Pointer#inspect is incompatible with FFI backend")
-      end
-
       ptr = Pointer.new(0)
       inspect = ptr.inspect
       assert_match(/size=#{ptr.size}/, inspect)


### PR DESCRIPTION
```ruby
p Fiddle::Pointer.new(1)
```

CRuby

```text
#<Fiddle::Pointer:0x0000600000983240 ptr=0x0000000000000001 size=0 free=0x0000000000000000>
```

JRuby before

```text
#<Fiddle::Pointer ptr=1 size=9223372036854775807 free=nil>
```

JRuby after

```text
#<Fiddle::Pointer ptr=0x0000000000000001 size=9223372036854775807 free=0x0000000000000000>
```

Note: `size` is incorrect for JRuby, which is not addressed with this PR