### PR TITLE
Fix memory corruption with FFI backend

### DIFF
--- a/lib/fiddle/ffi_backend.rb
+++ b/lib/fiddle/ffi_backend.rb
@@ -240,7 +240,7 @@ module Fiddle
     def self.to_ptr(value)
       if value.is_a?(String)
         cptr = Pointer.malloc(value.bytesize)
-        cptr.ffi_ptr.put_string(0, value)
+        cptr.ffi_ptr.put_bytes(0, value)
         cptr
 
       elsif value.is_a?(Array)

--- a/lib/fiddle/ffi_backend.rb
+++ b/lib/fiddle/ffi_backend.rb
@@ -412,7 +412,7 @@ module Fiddle
       if len
         ffi_ptr.read_string(len)
       else
-        ffi_ptr.get_string(0)
+        ffi_ptr.get_string(0, @size)
       end
     rescue FFI::NullPointerError
       raise DLError.new("NULL pointer access")


### PR DESCRIPTION
To reproduce with JRuby or TruffleRuby:

```ruby
require "fiddle"

1000.times do
  Fiddle::Pointer[rand(255).chr*16]
end
```

`put_string` adds a null byte at the end vs `write_bytes`. This is not caught by the bounds check since the underlying `FFI::Pointer` size is not set.