### PR TITLE
Fix pointer class for closure arguments for FFI backend

### DIFF
--- a/lib/fiddle/ffi_backend.rb
+++ b/lib/fiddle/ffi_backend.rb
@@ -188,8 +188,10 @@ module Fiddle
       end
       return_type = Fiddle::FFIBackend.to_ffi_type(@ctype)
       raise "#{self.class} must implement #call" unless respond_to?(:call)
-      callable = method(:call)
-      @function = FFI::Function.new(return_type, ffi_args, callable, convention: abi)
+      wrapper = lambda do |*args|
+        call(*args.map { |v| v.is_a?(FFI::Pointer) ? Pointer.new(v) : v })
+      end
+      @function = FFI::Function.new(return_type, ffi_args, wrapper, convention: abi)
       @freed = false
     end
 

--- a/test/fiddle/test_closure.rb
+++ b/test/fiddle/test_closure.rb
@@ -87,6 +87,20 @@ module Fiddle
       end
     end
 
+    def test_pointer
+      closure_class = Class.new(Closure) do
+        def call(ptr)
+          ptr.is_a?(Pointer)
+        end
+      end
+      closure_class.create(:bool, [:voidp]) do |closure|
+        func = Function.new(closure, [:voidp], :bool)
+        assert do
+          func.call(Pointer["hello"])
+        end
+      end
+    end
+
     def test_free
       closure_class = Class.new(Closure) do
         def call


### PR DESCRIPTION
Currently, pointer arguments for closures use the FFI pointer class instead of the Fiddle pointer class with the FFI backend.