### PR TITLE
Make pointer size consistent between backends

### DIFF
--- a/lib/fiddle/ffi_backend.rb
+++ b/lib/fiddle/ffi_backend.rb
@@ -323,7 +323,13 @@ module Fiddle
               FFI::Pointer.new(Integer(addr))
             end
 
-      @size = size ? size : (ptr.size_limit? ? ptr.size : 0)
+      if size
+        @size = size
+      elsif ptr.size_limit?
+        @size = ptr.size
+      else
+        @size = 0
+      end
       @free = free
       @ffi_ptr = ptr
       @freed = false

--- a/lib/fiddle/ffi_backend.rb
+++ b/lib/fiddle/ffi_backend.rb
@@ -323,7 +323,7 @@ module Fiddle
               FFI::Pointer.new(Integer(addr))
             end
 
-      @size = size ? size : ptr.size
+      @size = size ? size : (ptr.size_limit? ? ptr.size : 0)
       @free = free
       @ffi_ptr = ptr
       @freed = false
@@ -413,6 +413,8 @@ module Fiddle
     def to_s(len = nil)
       if len
         ffi_ptr.read_string(len)
+      elsif @size == 0
+        ffi_ptr.read_string
       else
         ffi_ptr.get_string(0, @size)
       end
@@ -486,6 +488,7 @@ module Fiddle
     def ref
       cptr = Pointer.malloc(FFI::Type::POINTER.size, RUBY_FREE)
       cptr.ffi_ptr.put_pointer(0, ffi_ptr)
+      cptr.size = 0
       cptr
     end
   end

--- a/test/fiddle/test_pointer.rb
+++ b/test/fiddle/test_pointer.rb
@@ -81,6 +81,9 @@ module Fiddle
 
       ptr[5] = 0
       assert_equal "hello\0world", ptr.to_str
+
+      ptr.size = 0
+      assert_equal "", ptr.to_str
     end
 
     def test_to_s
@@ -93,6 +96,9 @@ module Fiddle
       ptr[5] = 0
       assert_equal 'hello', ptr.to_s
       assert_equal "hello\0", ptr.to_s(6)
+
+      ptr.size = 0
+      assert_equal "hello", ptr.to_s
     end
 
     def test_minus
@@ -256,6 +262,8 @@ module Fiddle
       Pointer.malloc(4, Fiddle::RUBY_FREE) do |ptr|
         assert_equal 4, ptr.size
       end
+      assert_equal 0, Pointer.new(0).size
+      assert_equal 0, Pointer.new(0).ref.size
     end
 
     def test_size=


### PR DESCRIPTION
This PR makes the pointer size consistent between backends. Follow up to #179.

```ruby
require "fiddle"

ptr = Fiddle::Pointer.new(0)
p ptr.size
p ptr.ref.size

ptr = Fiddle::Pointer["hello world"]
ptr.size = 0
p ptr.to_s
p ptr.to_str
```

JRuby + TruffleRuby before

```text
9223372036854775807
8
""
""
```

CRuby + JRuby + TruffleRuby after

```text
0
0
"hello world"
""
```