### PR TITLE
Make `to_str` consistent between backends for negative pointer sizes

### DIFF
--- a/lib/fiddle/ffi_backend.rb
+++ b/lib/fiddle/ffi_backend.rb
@@ -432,6 +432,9 @@ module Fiddle
       if len
         ffi_ptr.read_string(len)
       else
+        if @size < 0
+          raise ArgumentError.new("negative string size (or size too big)")
+        end
         ffi_ptr.read_string(@size)
       end
     rescue FFI::NullPointerError

--- a/test/fiddle/test_pointer.rb
+++ b/test/fiddle/test_pointer.rb
@@ -84,6 +84,10 @@ module Fiddle
 
       ptr.size = 0
       assert_equal "", ptr.to_str
+      assert_equal "ello\0", (ptr + 1).to_str(5)
+      assert_raise(ArgumentError) do
+        (ptr + 1).to_str
+      end
     end
 
     def test_to_s
@@ -99,6 +103,8 @@ module Fiddle
 
       ptr.size = 0
       assert_equal "hello", ptr.to_s
+      assert_equal "ello\0", (ptr + 1).to_s(5)
+      assert_equal "ello", (ptr + 1).to_s
     end
 
     def test_minus
@@ -264,6 +270,7 @@ module Fiddle
       end
       assert_equal 0, Pointer.new(0).size
       assert_equal 0, Pointer.new(0).ref.size
+      assert_equal -1, (Pointer.new(0) + 1).size
     end
 
     def test_size=


### PR DESCRIPTION
Also added more tests for the current behavior.

```ruby
require "fiddle"

ptr = Fiddle::Pointer["hello\0world"]
ptr.size = 0

p (ptr + 1).size
p (ptr + 1).to_s(5)
p (ptr + 1).to_s
p (ptr + 1).to_str(5)
p (ptr + 1).to_str
```

Output

```text
-1
"ello\x00"
"ello"
"ello\x00"
repro.rb:10:in 'Fiddle::Pointer#to_str': negative string size (or size too big) (ArgumentError)
```