### PR TITLE
Fix `Fiddle::Pointer#ref` behavior for FFI backend

### DIFF
--- a/lib/fiddle/ffi_backend.rb
+++ b/lib/fiddle/ffi_backend.rb
@@ -218,6 +218,7 @@ module Fiddle
   class DLError < Error; end
   class ClearedReferenceError < Error; end
 
+  # Pointer isn't thread safe for now
   class Pointer
     extend FFI::DataConverter
     native_type FFI::Type::Builtin::POINTER

--- a/test/fiddle/test_pointer.rb
+++ b/test/fiddle/test_pointer.rb
@@ -187,6 +187,19 @@ module Fiddle
       assert_nil(ptr <=> 10, '10 should not be comparable')
     end
 
+    def test_ref
+      ptr = Fiddle::Pointer["hello"]
+      ref = ptr.ref
+      assert_equal(0, ref.size)
+      assert_nil(ref.free)
+      assert_equal(ptr, ref.ptr)
+
+      ptr2 = Fiddle::Pointer["world"]
+      ptr.ref[0, Fiddle::SIZEOF_VOIDP] = ptr2.ref
+      assert_equal("world", ptr.to_s)
+      assert_equal(ptr.to_i, ptr2.to_i)
+    end
+
     def test_ref_ptr
       if ffi_backend?
         omit("Fiddle.dlwrap([]) isn't supported with FFI backend")


### PR DESCRIPTION
Fixes #182 by making the pointer address dynamic.

```ruby
require "fiddle"

ptr = Fiddle::Pointer["hello"]
ptr.ref[0, Fiddle::SIZEOF_VOIDP] = Fiddle::Pointer["world"].ref
p ptr.to_s
```

The code above previously returned `"hello"` with the FFI backend.