### PR TITLE
Restore null byte in to_ptr for FFI backend

### DIFF
--- a/lib/fiddle/ffi_backend.rb
+++ b/lib/fiddle/ffi_backend.rb
@@ -241,9 +241,7 @@ module Fiddle
 
     def self.to_ptr(value)
       if value.is_a?(String)
-        cptr = Pointer.malloc(value.bytesize)
-        cptr.ffi_ptr.put_bytes(0, value)
-        cptr
+        Pointer.new(FFI::MemoryPointer.from_string(value), value.bytesize)
 
       elsif value.is_a?(Array)
         raise NotImplementedError, "array ptr"

--- a/test/fiddle/test_pointer.rb
+++ b/test/fiddle/test_pointer.rb
@@ -134,6 +134,8 @@ module Fiddle
       ptr = Pointer[str]
       assert_equal str.length, ptr.size
       assert_equal 'hello', ptr[0,5]
+      assert_equal 0, Fiddle::Pointer.to_ptr("abc")[3]
+      assert_equal "world", Fiddle::Pointer.to_ptr("hello\0world")[6,5]
     end
 
     def test_to_ptr_io


### PR DESCRIPTION
Addresses https://github.com/ruby/fiddle/pull/180#discussion_r2059164448