### PR TITLE
Fix "ambiguous first argument" warning in test suite

### DIFF
--- a/test/fiddle/test_pointer.rb
+++ b/test/fiddle/test_pointer.rb
@@ -281,7 +281,7 @@ module Fiddle
 
     def test_size
       Pointer.malloc(4, Fiddle::RUBY_FREE) do |ptr|
-        assert_equal 4, ptr.size
+        assert_equal(4, ptr.size)
       end
       assert_equal(0, Pointer.new(0).size)
       assert_equal(0, Pointer.new(0).ref.size)

--- a/test/fiddle/test_pointer.rb
+++ b/test/fiddle/test_pointer.rb
@@ -285,7 +285,7 @@ module Fiddle
       end
       assert_equal 0, Pointer.new(0).size
       assert_equal 0, Pointer.new(0).ref.size
-      assert_equal -1, (Pointer.new(0) + 1).size
+      assert_equal(-1, (Pointer.new(0) + 1).size)
     end
 
     def test_size=

--- a/test/fiddle/test_pointer.rb
+++ b/test/fiddle/test_pointer.rb
@@ -283,8 +283,8 @@ module Fiddle
       Pointer.malloc(4, Fiddle::RUBY_FREE) do |ptr|
         assert_equal 4, ptr.size
       end
-      assert_equal 0, Pointer.new(0).size
-      assert_equal 0, Pointer.new(0).ref.size
+      assert_equal(0, Pointer.new(0).size)
+      assert_equal(0, Pointer.new(0).ref.size)
       assert_equal(-1, (Pointer.new(0) + 1).size)
     end
 


### PR DESCRIPTION
```
test/fiddle/test_pointer.rb:288: warning: ambiguous first argument;
put parentheses or a space even after '-' operator
```

I noticed this in one of my ruby builds: https://github.com/ruby/ruby/actions/runs/14838247932/job/41654544867?pr=13159#step:8:1818

cc @kou @ankane 