### PR TITLE
CI: Add GitHub Actions ppc64le/s390x cases

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,6 +77,40 @@ jobs:
           cd tmp
           ruby test/run.rb
 
+  host-ibm:
+    if: github.repository == 'ruby/fiddle'
+    name: ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os:
+          - ubuntu-24.04-ppc64le
+          - ubuntu-24.04-s390x
+
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Set up Ruby
+        run: |
+          sudo apt-get update
+          sudo apt-get install ruby-full bundler libffi-dev
+
+      - run: sudo bundle install --jobs $(nproc)
+
+      - run: rake compile
+
+      - run: ruby -Ilib test/run.rb
+
+      - run: sudo rake install
+
+      - name: Run test against installed gem
+        run: |
+          ruby -run -e mkdir -- -p tmp/
+          ruby -run -e cp -- -pr test/ tmp/
+          cd tmp
+          ruby test/run.rb
+
   docker:
     name: >-
       ${{ matrix.service }}


### PR DESCRIPTION
This PR is working in progress to add GitHub Actions Ubuntu 24.04 ppc64le/s390x cases. This is one of the tasks that we add the cases in some ruby/* repositories. The task is tracked at https://github.com/IBM/actionspz/issues/4#issuecomment-3109205041.

Maybe, this PR's change will be for only `.github/workflows/ci.yml`, while you see other changes in other files temporarily to work on this PR easily for now. I needed to sent a PR to this repository to test the ppc64le/s390x CI pipelines, rather than to test on my fork repository because GitHub Actions Ubuntu 24.04 ppc64le/s390x cases don't work in fork repositories unlike GitHub Actions x86_64/arm64 pipelines. 

I add the new job "host-ibm", because there are ppc64le/s390x specific logic, `if: github.repository == 'ruby/fiddle'` and  "Set up Ruby" logic installing Ruby apt package. The `ruby/setup-ruby` doesn't support the ppc64le/s390x cases as far as I know.

As a reference, we have applied the following code to a few ruby/* repositories.

* ruby/ruby: https://github.com/ruby/ruby/blob/master/.github/workflows/ubuntu-ibm.yml
* ruby/prism: https://github.com/ruby/prism/blob/07de61d4702d12c985d0a708445cf6f3e1935989/.github/workflows/main.yml#L81-L100
* ruby/psych: https://github.com/ruby/psych/blob/1d9c52706b2572a37248a1bdf3f83cc6ef07fd83/.github/workflows/test.yml#L64-L86
* ruby/zlib: https://github.com/ruby/zlib/blob/b2ec227080d79fb16e7df2659c8fe943b5a9452d/.github/workflows/test.yml#L45-L64