### PR TITLE
CI: Add the `bundle exec`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,18 +49,18 @@ jobs:
 
       - run: bundle install
 
-      - run: rake compile
+      - run: bundle exec rake compile
 
       # If Fiddle in Ruby's master has the same version of this Fiddle,
       # "gem install pkg/*.gem" fails.
-      - run: rake version:bump
+      - run: bundle exec rake version:bump
         if: >-
           matrix.ruby == 'debug' ||
           matrix.ruby == 'mingw' ||
           matrix.ruby == 'mswin'
 
       # This is for ensuring using Fiddle in this repository.
-      - run: ruby -Ilib test/run.rb
+      - run: bundle exec ruby -Ilib test/run.rb
 
       - run: rake install
 
@@ -98,9 +98,9 @@ jobs:
 
       - run: sudo bundle install --jobs $(nproc)
 
-      - run: rake compile
+      - run: bundle exec rake compile
 
-      - run: ruby -Ilib test/run.rb
+      - run: bundle exec ruby -Ilib test/run.rb
 
       - run: sudo rake install
 

--- a/.github/workflows/libffi.yml
+++ b/.github/workflows/libffi.yml
@@ -32,20 +32,20 @@ jobs:
       - name: Install dependencies
         run: bundle install
       - name: Compile with libffi
-        run: rake compile -- --with-libffi-dir=${{ matrix.libffi-prefix }}
+        run: bundle exec rake compile -- --with-libffi-dir=${{ matrix.libffi-prefix }}
         if: ${{ matrix.libffi-prefix != '' }}
       - name: Compile with libffi source
-        run: rake compile -- --with-libffi-source-dir=$(pwd)/libffi-${{ matrix.libffi }}
+        run: bundle exec rake compile -- --with-libffi-source-dir=$(pwd)/libffi-${{ matrix.libffi }}
         if: ${{ matrix.libffi-prefix == '' }}
       - name: Run test
         run: rake test
       - name: Install gem
         run: |
-          rake build
+          bundle exec rake build
           gem install pkg/fiddle-*.gem -- --with-libffi-dir=${{ matrix.libffi-prefix }}
         if: ${{ matrix.ruby != 'head' && matrix.libffi-prefix != '' }}
       - name: Install gem with libffi source
         run: |
-          rake build
+          bundle exec rake build
           gem install pkg/fiddle-*.gem -- --with-libffi-source-dir=$(pwd)/libffi-${{ matrix.libffi }}
         if: ${{ matrix.ruby != 'head' && matrix.libffi-prefix == '' }}


### PR DESCRIPTION
Add the `bundle exec` if we can add it to the commands. I didn't add the `bundle exec` for the `rake install`, `rake test` commands, because I saw the following failures when adding the `bundle exec` to these commands.

* .github/workflows/ci.yml - step `bundle exec rake install`. https://github.com/junaruga/ruby-fiddle/actions/runs/17922685051/job/50961337638
* .github/workflows/libffi.yml - step "Run test" - `bundle exec rake test` failed in the `test_no_memory_leak`. https://github.com/junaruga/ruby-fiddle/actions/runs/17922685028/job/50961337379