### PR TITLE
Remove warning by not calling have_library after pkg_config

### DIFF
--- a/ext/fiddle/extconf.rb
+++ b/ext/fiddle/extconf.rb
@@ -64,18 +64,21 @@ unless bundle
   dir_config 'libffi'
 
   if pkg_config("libffi")
+    have_libffi = true
     libffi_version = pkg_config("libffi", "modversion")
   end
 
-  have_ffi_header = false
-  if have_header(ffi_header = 'ffi.h')
-    have_ffi_header = true
-  elsif have_header(ffi_header = 'ffi/ffi.h')
-    $defs.push('-DUSE_HEADER_HACKS')
-    have_ffi_header = true
-  end
-  if have_ffi_header && (have_library('ffi') || have_library('libffi'))
-    have_libffi = true
+  unless have_libffi
+    have_ffi_header = false
+    if have_header(ffi_header = 'ffi.h')
+      have_ffi_header = true
+    elsif have_header(ffi_header = 'ffi/ffi.h')
+      $defs.push('-DUSE_HEADER_HACKS')
+      have_ffi_header = true
+    end
+    if have_ffi_header && (have_library('ffi') || have_library('libffi'))
+      have_libffi = true
+    end
   end
 end
 


### PR DESCRIPTION
pkg_config without the options arguments stores the result in the global values.

Calling `pkg_config` and `have_library` causes -lffi to appear twice in the LIBS variable in the resulting Makefile, and causes ld on macOS to emit a warning:

    $ bundle exec rake compile 2>&1 | grep warning:
    ld: warning: ignoring duplicate libraries: '-lffi'