### PR TITLE
Add support for rubygems-requirements-system

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,11 +18,31 @@ gem 'fiddle'
 
 And then execute:
 
-    $ bundle
+```console
+$ bundle
+```
 
 Or install it yourself as:
 
-    $ gem install fiddle
+```console
+$ gem install fiddle
+```
+
+If you want to install libffi automatically, you can use [rubygems-requirements-system](https://rubygems.org/gems/rubygems-requirements-system).
+
+If you use `Gemfile`, you need to add rubygems-requirements-system to plugins:
+
+```ruby
+plugin 'rubygems-requirements-system'
+gem 'fiddle'
+```
+
+If you use `gem`, you need install rubygems-requirements-system before installing Fiddle:
+
+```console
+$ gem install rubygems-requirements-system
+$ gem install fiddle
+```
 
 ## Usage
 

--- a/fiddle.gemspec
+++ b/fiddle.gemspec
@@ -54,4 +54,14 @@ Gem::Specification.new do |spec|
 
   spec.metadata["msys2_mingw_dependencies"] = "libffi"
   spec.metadata["changelog_uri"] = "https://github.com/ruby/fiddle/releases"
+
+  spec.requirements << "system: libffi: alpine_linux: libffi-dev"
+  spec.requirements << "system: libffi: alt_linux: libffi-devel"
+  spec.requirements << "system: libffi: arch_linux: libffi"
+  spec.requirements << "system: libffi: conda: libffi"
+  spec.requirements << "system: libffi: debian: libffi-dev"
+  spec.requirements << "system: libffi: gentoo_linux: dev-libs/libffi"
+  spec.requirements << "system: libffi: homebrew: libffi"
+  spec.requirements << "system: libffi: macports: libffi"
+  spec.requirements << "system: libffi: rhel: pkgconfig(libffi)"
 end


### PR DESCRIPTION
Users can install libffi automatically by
rubygems-requirements-system.