### PR TITLE
Don't run TruffleRuby on macOS with Intel CPU on CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,6 +38,7 @@ jobs:
           - { os: macos-15  , ruby: '2.5' }
           - { os: windows-latest , ruby: debug }
           - { os: windows-latest , ruby: truffleruby }
+          - { os: macos-15-intel , ruby: truffleruby }
 
     steps:
       - uses: actions/checkout@v6


### PR DESCRIPTION
Support of macOS + Intel was dropped in the recent TruffleRuby release. So remove a corresponding CI job.

cc @eregon 