### PR TITLE
Avoid redefining FFI_GO_CLOSURES defined by libffi headers

### DIFF
--- a/ext/fiddle/extconf.rb
+++ b/ext/fiddle/extconf.rb
@@ -162,6 +162,16 @@ unless have_libffi
   $INCFLAGS << " -I" << libffi.include
 end
 
+unless macro_defined?("FFI_GO_CLOSURES", cpp_include(ffi_header || 'ffi.h'))
+  # ffi.h in libffi 3.4.4 or earlier and the macOS SDK uses
+  # `#if FFI_GO_CLOSURES`, which warns with -Wundef on targets whose
+  # ffitarget.h does not define it.  Newer libffi defines it in
+  # ffitarget.h unconditionally, where defining it on our side would be
+  # a macro redefinition (e.g. warning C4005 with MSVC).  Fiddle does
+  # not use Go closures.
+  $defs.push('-DFFI_GO_CLOSURES=0')
+end
+
 if libffi_version
   # If libffi_version contains rc version, just ignored.
   libffi_version = libffi_version.gsub(/-rc\d+/, '')

--- a/ext/fiddle/fiddle.h
+++ b/ext/fiddle/fiddle.h
@@ -40,7 +40,6 @@
 # endif
 #endif
 
-#define FFI_GO_CLOSURES 0 /* fiddle does not use go closures */
 #ifdef USE_HEADER_HACKS
 #include <ffi/ffi.h>
 #else


### PR DESCRIPTION
Building fiddle with MSVC against libffi whose `ffitarget.h` defines `FFI_GO_CLOSURES` unconditionally, for example vcpkg libffi 3.5.2 in a ruby/ruby mswin build, reports `warning C4005: 'FFI_GO_CLOSURES': macro redefinition` in every compilation unit. The pre-definition in `fiddle.h` added by #157 collides with libffi's own definition. GCC and clang hide the same redefinition because it happens in a system header there.

The pre-definition only exists to silence `-Wundef` warnings from old `ffi.h` that tests `#if FFI_GO_CLOSURES` without the target defining it, and libffi switched that test to `#ifdef` in 3.4.5 (libffi/libffi#796). This restores the conditional approach of #134, but detects whether the libffi headers define the macro with `macro_defined?` at `extconf.rb` time instead of matching compiler-specific warning text, and defines `FFI_GO_CLOSURES=0` only when they do not. Fiddle itself does not use Go closures, so the macro only affects which declarations `ffi.h` exposes.

I verified on Windows with MSVC that the eight C4005 warnings disappear with vcpkg libffi 3.5.2, and that a simulated old libffi header set with no `FFI_GO_CLOSURES` definition and an `#if FFI_GO_CLOSURES` test still gets `-DFFI_GO_CLOSURES=0` from `extconf.rb`. `rake test` passes on `x64-mswin64_140`.

Generated with [Claude Code](https://claude.com/claude-code)
